### PR TITLE
Marking the operator as fips compliant

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:3.0.0-tp-latest
-    createdAt: "2024-05-07T06:06:25Z"
+    createdAt: "2024-05-07T07:35:32Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure,
       and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service
       Mesh is based on the open source Istio project.
@@ -42,7 +42,7 @@ metadata:
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -12,6 +12,7 @@ service:
 serviceAccountName: servicemesh-operator3
 csv:
   annotations:
+    features.operators.openshift.io/fips-compliant: "true"
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
   displayName: Red Hat OpenShift Service Mesh 3
   categories: OpenShift Optional, Integration & Delivery, Networking, Security


### PR DESCRIPTION
This will enable FIPS scanner during a CVP run so we can start fixing potential issues.
Also it should resolve the warning: [INVALID] The value of the 'features.operators.openshift.io/fips-compliant' annotation from the operator CSV is: false. The value can only be a string "true".