### PR TITLE
Update cert-manager integration with recommended doc style

### DIFF
--- a/docs/ossm/cert-manager/README.md
+++ b/docs/ossm/cert-manager/README.md
@@ -30,66 +30,86 @@ You can install the cert-manager tool to manage the lifecycle of TLS certificate
 
 ### Procedure
 
-1.  Create the `istio-system` namespace:
+1.  Create the `istio-system` namespace.
 
     ```sh
     oc create namespace istio-system
     ```
 
-2.  Create the root cluster issuer:
+2.  Create the root cluster issuer.
 
-    ```sh
-    oc apply -f - <<EOF
-    apiVersion: cert-manager.io/v1
-    kind: Issuer
-    metadata:
-      name: selfsigned
-      namespace: istio-system
-    spec:
-      selfSigned: {}
-    ---
-    apiVersion: cert-manager.io/v1
-    kind: Certificate
-    metadata:
-      name: istio-ca
-      namespace: istio-system
-    spec:
-      isCA: true
-      duration: 87600h # 10 years
-      secretName: istio-ca
-      commonName: istio-ca
-      privateKey:
-        algorithm: ECDSA
-        size: 256
-      subject:
-        organizations:
-          - cluster.local
-          - cert-manager
-      issuerRef:
+    - Create the `Issuer` object as in the following example:
+
+      _Example `cluster-issuer.yaml`_
+
+      ```yaml
+      apiVersion: cert-manager.io/v1
+      kind: Issuer
+      metadata:
         name: selfsigned
-        kind: Issuer
-        group: cert-manager.io
-    ---
-    apiVersion: cert-manager.io/v1
-    kind: Issuer
-    metadata:
-      name: istio-ca
-      namespace: istio-system
-    spec:
-      ca:
+        namespace: istio-system
+      spec:
+        selfSigned: {}
+      ---
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: istio-ca
+        namespace: istio-system
+      spec:
+        isCA: true
+        duration: 87600h # 10 years
         secretName: istio-ca
-    EOF
-    oc wait --for=condition=Ready certificates/istio-ca -n istio-system
-    ```
+        commonName: istio-ca
+        privateKey:
+          algorithm: ECDSA
+          size: 256
+        subject:
+          organizations:
+            - cluster.local
+            - cert-manager
+        issuerRef:
+          name: selfsigned
+          kind: Issuer
+          group: cert-manager.io
+      ---
+      apiVersion: cert-manager.io/v1
+      kind: Issuer
+      metadata:
+        name: istio-ca
+        namespace: istio-system
+      spec:
+        ca:
+          secretName: istio-ca
+      ```
 
-3.  Export the Root CA to the `cert-manager` namespace:
+    - Create the objects by using the following command.
 
-    ```sh
-    oc get -n istio-system secret istio-ca -o jsonpath='{.data.tls\.crt}' | base64 -d > ca.pem
-    oc create secret generic -n cert-manager istio-root-ca --from-file=ca.pem=ca.pem
-    ```
+      ```sh
+      oc apply -f cluster-issuer.yaml
+      ```
 
-4.  Install istio-csr:
+    - Wait for the `istio-ca` certificate to become ready.
+      ```sh
+      oc wait --for=condition=Ready certificates/istio-ca -n istio-system
+      ```
+
+3.  Export the Root CA to a local file.
+
+    Here we are copying our `istio-ca` certificate to the `cert-manager` namespace where it can be used by istio-csr.
+
+    - Copy the secret to a local file.
+
+      ```sh
+      oc get -n istio-system secret istio-ca -o jsonpath='{.data.tls\.crt}' | base64 -d > ca.pem
+      ```
+
+    - Create a secret from the local cert file in the `cert-manager` namespace.
+      ```sh
+      oc create secret generic -n cert-manager istio-root-ca --from-file=ca.pem=ca.pem
+      ```
+
+4.  Install istio-csr.
 
     Next you will install istio-csr into the `cert-manager` namespace. Depending on which `updateStrategy` (`InPlace` or `RevisionBased`) you will choose for your `Istio` resource, you may need to pass additional options.
 
@@ -99,19 +119,25 @@ You can install the cert-manager tool to manage the lifecycle of TLS certificate
 
     `InPlace` strategy installation
 
-    ```sh
-    helm repo add jetstack https://charts.jetstack.io --force-update
-    helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
-        --install \
-        --namespace cert-manager \
-        --wait \
-        --set "app.tls.rootCAFile=/var/run/secrets/istio-csr/ca.pem" \
-        --set "volumeMounts[0].name=root-ca" \
-        --set "volumeMounts[0].mountPath=/var/run/secrets/istio-csr" \
-        --set "volumes[0].name=root-ca" \
-        --set "volumes[0].secret.secretName=istio-root-ca" \
-        --set "app.istio.namespace=istio-system"
-    ```
+    - Add the jetstack charts to your local helm repo.
+
+      ```sh
+      helm repo add jetstack https://charts.jetstack.io --force-update
+      ```
+
+    - Install the istio-csr chart.
+      ```sh
+      helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+          --install \
+          --namespace cert-manager \
+          --wait \
+          --set "app.tls.rootCAFile=/var/run/secrets/istio-csr/ca.pem" \
+          --set "volumeMounts[0].name=root-ca" \
+          --set "volumeMounts[0].mountPath=/var/run/secrets/istio-csr" \
+          --set "volumes[0].name=root-ca" \
+          --set "volumes[0].secret.secretName=istio-root-ca" \
+          --set "app.istio.namespace=istio-system"
+      ```
 
     `RevisionBased` strategy installation
 
@@ -121,107 +147,133 @@ You can install the cert-manager tool to manage the lifecycle of TLS certificate
     oc get istiorevisions
     ```
 
-    Install `istio-csr`
+    - Add the jetstack charts to your local helm repo.
 
-    ```sh
-    helm repo add jetstack https://charts.jetstack.io --force-update
-    helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
-        --install \
-        --namespace cert-manager \
-        --wait \
-        --set "app.tls.rootCAFile=/var/run/secrets/istio-csr/ca.pem" \
-        --set "volumeMounts[0].name=root-ca" \
-        --set "volumeMounts[0].mountPath=/var/run/secrets/istio-csr" \
-        --set "volumes[0].name=root-ca" \
-        --set "volumes[0].secret.secretName=istio-root-ca" \
-        --set "app.istio.namespace=istio-system" \
-        --set "app.istio.revisions={default-v1-23-0}"
-    ```
+      ```sh
+      helm repo add jetstack https://charts.jetstack.io --force-update
+      ```
 
-5.  Install your `Istio` resource. Here we are disabling Istio's built in CA server and instead pointing istiod to the istio-csr CA server which will issue certificates for both istiod and user workloads. Additionally we mount the istiod certificate in a known location where it will be read by istiod. Mounting the certificates to a known location is only necessary on OSSM.
+    - Install the istio-csr chart with your revision name.
+      ```sh
+      helm repo add jetstack https://charts.jetstack.io --force-update
+      helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
+          --install \
+          --namespace cert-manager \
+          --wait \
+          --set "app.tls.rootCAFile=/var/run/secrets/istio-csr/ca.pem" \
+          --set "volumeMounts[0].name=root-ca" \
+          --set "volumeMounts[0].mountPath=/var/run/secrets/istio-csr" \
+          --set "volumes[0].name=root-ca" \
+          --set "volumes[0].secret.secretName=istio-root-ca" \
+          --set "app.istio.namespace=istio-system" \
+          --set "app.istio.revisions={default-v1-23-0}"
+      ```
 
-    ```sh
-    oc apply -f - <<EOF
-    apiVersion: sailoperator.io/v1alpha1
-    kind: Istio
-    metadata:
-      name: default
-    spec:
-      version: v1.23.0
-      namespace: istio-system
-      values:
-        global:
-          caAddress: cert-manager-istio-csr.cert-manager.svc:443
-        pilot:
-          env:
-            ENABLE_CA_SERVER: "false"
-          volumeMounts:
-            - mountPath: /tmp/var/run/secrets/istiod/tls
-              name: istio-csr-dns-cert
-              readOnly: true
-    EOF
-    ```
+5.  Install your `Istio` resource.
+
+    Here we are disabling Istio's built in CA server and instead pointing istiod to the istio-csr CA server which will issue certificates for both istiod and the mesh workloads.
+
+    - Create the `Istio` object as in the following example:
+
+      _Example `istio.yaml`_
+
+      ```yaml
+      apiVersion: sailoperator.io/v1alpha1
+      kind: Istio
+      metadata:
+        name: default
+      spec:
+        version: v1.23.0
+        namespace: istio-system
+        values:
+          global:
+            caAddress: cert-manager-istio-csr.cert-manager.svc:443
+          pilot:
+            env:
+              ENABLE_CA_SERVER: "false"
+      ```
+
+    - Create the `Istio` resource by using the following command.
+
+      ```sh
+      oc apply -f istio.yaml
+      ```
+
+    - Wait for `Istio` to become ready.
+      ```sh
+      oc wait --for=condition=Ready istios/default -n istio-system
+      ```
 
 6.  Verification
 
     Use the sample httpbin service and sleep app to check traffic between the workloads is possible and check the workload certificate of the proxy to verify that the cert-manager tool is installed correctly.
 
-    a. Create the `sample` namespace:
+    - Create the `sample` namespace.
 
-    ```sh
-    oc new-project sample
-    ```
+      ```sh
+      oc new-project sample
+      ```
 
-    b. Find your active `IstioRevision`:
+    - Find your active `IstioRevision`.
 
-    ```sh
-    oc get istiorevisions
-    ```
+      ```sh
+      oc get istiorevisions
+      ```
 
-    c. Add the injection label for your active revision to the `sample` namespace:
+    - Add the injection label for your active revision to the `sample` namespace.
 
-    ```sh
-    oc label namespace sample istio.io/rev=<your-active-revision-name> --overwrite=true
-    ```
+      ```sh
+      oc label namespace sample istio.io/rev=<your-active-revision-name> --overwrite=true
+      ```
 
-    d. Deploy the HTTP and sleep apps:
+    - Deploy the sample `httpbin` app.
 
-    ```sh
-    oc apply -n sample -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/httpbin/httpbin.yaml
-    oc apply -n sample -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/sleep/sleep.yaml
-    oc rollout status deployment httpbin sleep
-    ```
+      ```sh
+      oc apply -n sample -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/httpbin/httpbin.yaml
+      ```
 
-    e. Verify that sleep can access the httpbin service:
+    - Deploy the sample `sleep` app.
 
-    ```sh
-    oc exec "$(oc get pod -l app=sleep -n sample \
-      -o jsonpath={.items..metadata.name})" -c sleep -n sample -- \
-      curl http://httpbin.sample:8000/ip -s -o /dev/null \
-      -w "%{http_code}\n"
-    ```
+      ```sh
+      oc apply -n sample -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/sleep/sleep.yaml
+      ```
 
-    Example output
+    - Wait for both apps to become ready.
 
-    ```sh
-    200
-    ```
+      ```sh
+      oc rollout status -n sample deployment httpbin sleep
+      ```
 
-    f. Verify `httpbin` workload certificate matches what is expected:
+    - Verify that sleep can access the httpbin service:
 
-    ```sh
-    istioctl proxy-config secret -n sample $(oc get pods -n sample -o jsonpath='{.items..metadata.name}' --selector app=httpbin) -o json | jq -r '.dynamicActiveSecrets[0].secret.tlsCertificate.certificateChain.inlineBytes' | base64 --decode | openssl x509 -text -noout
-    ```
+      ```sh
+      oc exec "$(oc get pod -l app=sleep -n sample \
+        -o jsonpath={.items..metadata.name})" -c sleep -n sample -- \
+        curl http://httpbin.sample:8000/ip -s -o /dev/null \
+        -w "%{http_code}\n"
+      ```
 
-    Example output
+      Example output
 
-    ```sh
-    ...
-    Issuer: O = cert-manager + O = cluster.local, CN = istio-ca
-    ...
-    X509v3 Subject Alternative Name:
-      URI:spiffe://cluster.local/ns/sample/sa/httpbin
-    ```
+      ```sh
+      200
+      ```
+
+    - Verify `httpbin` workload certificate matches what is expected:
+
+      ```sh
+      istioctl proxy-config secret -n sample $(oc get pods -n sample -o jsonpath='{.items..metadata.name}' --selector app=httpbin) -o json | jq -r '.dynamicActiveSecrets[0].secret.tlsCertificate.certificateChain.inlineBytes' | base64 --decode | openssl x509 -text -noout
+      ```
+
+      Example output
+
+      ```sh
+      ...
+      Issuer: O = cert-manager + O = cluster.local, CN = istio-ca
+      ...
+      X509v3 Subject Alternative Name:
+        URI:spiffe://cluster.local/ns/sample/sa/httpbin
+      ```
 
 ### `RevisionBased` Upgrades
 


### PR DESCRIPTION
Updates the cert-manager integration docs with the recommended doc style.

Keeps the workaround for the working dir pilot image since this won't be fixed till tp2.