### PR TITLE
Adding replaces to make the upgrade to tp2 work

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:3.0-latest
-    createdAt: "2024-12-11T14:30:09Z"
+    createdAt: "2024-12-12T10:28:38Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure,
       and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service
       Mesh is based on the open source Istio project.
@@ -743,4 +743,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc.
+  replaces: servicemeshoperator3.v3.0.0-tp.1
   version: 3.0.0-tp.2

--- a/chart/templates/olm/clusterserviceversion.yaml
+++ b/chart/templates/olm/clusterserviceversion.yaml
@@ -20,6 +20,8 @@ metadata:
   name: {{ .Values.name }}.v{{ .Values.csv.version }}
   namespace: placeholder
 spec:
+  # TODO, hardcoded workaround
+  replaces: servicemeshoperator3.v3.0.0-tp.1
   apiservicedefinitions: {}
   description: |-
 {{ indent 4 .Values.csv.longDescription }}


### PR DESCRIPTION
This is a tmp workaround only for tp2 upgrade. It should not be needed for GA


