### PR TITLE
OSSM-6337: add cleaning of 2.6 after migration

### DIFF
--- a/docs/ossm/ossm2-migration/README.md
+++ b/docs/ossm/ossm2-migration/README.md
@@ -126,4 +126,4 @@ Now you are ready to migrate. Check the `spec.mode` field on your `ServiceMeshCo
 oc get smcp <smcp-name> -n <smcp-namespace> -o jsonpath='{.spec.mode}'
 ```
 
-For `MultiTenant` meshes, follow [these instructions](./multi-tenancy/README.md). For `ClusterWide` meshes, follow [these instructions](#TODO).
+For `MultiTenant` meshes, follow [these instructions](./multi-tenancy/README.md). For `ClusterWide` meshes, follow [these instructions](./cluster-wide/README.md). When the migration is finished, follow [these instructions](./cleaning-2.6/README.md) to remove OpenShift Service Mesh 2.6.

--- a/docs/ossm/ossm2-migration/cleaning-2.6/README.md
+++ b/docs/ossm/ossm2-migration/cleaning-2.6/README.md
@@ -1,0 +1,63 @@
+# Cleaning of OpenShift Service Mesh 2.6 after migration
+When the migration of all workloads is finished, it's possible to remove OpenShift Service Mesh 2.6 installation.
+
+## Remove 2.6 control planes
+1. Find all Service Mesh 2.6 resources:
+    ```sh
+    oc get smcp,smm,smmr -A
+    ```
+1. Remove all found `ServiceMeshControlPlane`
+    ```sh
+    oc delete smcp basic -n istio-system
+    ```
+1. Remove all found `ServiceMeshMemberRoll`
+    ```sh
+    oc delete smmr default -n istio-system
+    ```
+1. Remove all found `ServiceMeshMembers`
+    ```sh
+    oc delete smm default -n bookinfo
+    ```
+1. Verify that all resources were removed:
+    ```sh
+    oc get smcp,smm,smmr -A
+    No resources found
+    ```
+
+> **_NOTE:_** that depending on how you created `ServiceMeshMembers` and `ServiceMeshMemberRoll`, those resources might be removed automatically with removal of `ServiceMeshControlPlane` after step 2.
+
+## Remove 2.6 operator and CRDs
+1. Make sure there are no Service Mesh 2.6 resources left:
+    ```sh
+    oc get smcp,smm,smmr -A
+    No resources found
+    ```
+1. Remove the operator
+    ```sh
+    csv=$(oc get subscription servicemeshoperator -n openshift-operators -o yaml | grep currentCSV | cut -f 2 -d ':')
+    oc delete subscription servicemeshoperator -n openshift-operators
+    oc delete clusterserviceversion $csv -n openshift-operators
+    ```
+1. Remove Maistra CRDs
+    ```sh
+    oc get crds -o name | grep ".*\.maistra\.io" | xargs -r -n 1 oc delete
+    ```
+
+## Remove Maistra labels
+Optionally you can remove namespace labels created during the migration.
+1. Make sure there are no Service Mesh 2.6 resources left:
+    ```sh
+    oc get smcp,smm,smmr -A
+    No resources found
+    ```
+1. Find namespaces with the `maistra.io/ignore-namespace="true"` label:
+    ```sh
+    oc get namespace -l maistra.io/ignore-namespace="true"
+    NAME            STATUS   AGE
+    bookinfo   Active   127m
+    ```
+1. Remove the label:
+    ```sh
+    oc label namespace bookinfo maistra.io/ignore-namespace-
+    namespace/bookinfo unlabeled
+    ```

--- a/docs/ossm/ossm2-migration/cleaning-2.6/README.md
+++ b/docs/ossm/ossm2-migration/cleaning-2.6/README.md
@@ -45,7 +45,7 @@ When the migration of all workloads is finished, it's possible to remove OpenShi
 
 ## Remove Maistra labels
 Optionally you can remove namespace labels created during the migration.
-1. Make sure there are no Service Mesh 2.6 resources left:
+1. Following resources should be already removed in previous steps but it's important to be sure there are no Service Mesh 2.6 resources left before removing the label:
     ```sh
     oc get smcp,smm,smmr -A
     No resources found

--- a/docs/ossm/ossm2-migration/cluster-wide/README.md
+++ b/docs/ossm/ossm2-migration/cluster-wide/README.md
@@ -365,3 +365,6 @@ You can now proceed with the migration of next namespace.
 
 > [!CAUTION]
 > Do not remove `maistra.io/ignore-namespace="true"` label until the 2.6 control plane is uninstalled.
+
+### Cleaning of OpenShift Service Mesh 2.6
+Follow [these instructions.](../cleaning-2.6/README.md)

--- a/docs/ossm/ossm2-migration/multi-tenancy/README.md
+++ b/docs/ossm/ossm2-migration/multi-tenancy/README.md
@@ -302,3 +302,5 @@ oc create ns istio-system-tenant-a
          </dl>
    ...
    ```
+### Cleaning of OpenShift Service Mesh 2.6
+Follow [these instructions.](../cleaning-2.6/README.md)


### PR DESCRIPTION
Adding doc for cleaning of 2.6 after migration.

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [x] Documentation Update

