### PR TITLE
Add checks for kiali and CRD versions to migration checker

### DIFF
--- a/docs/ossm/ossm2-migration/migration-checker.sh
+++ b/docs/ossm/ossm2-migration/migration-checker.sh
@@ -260,11 +260,11 @@ check_kialis() {
     # Check Kiali operator
     # Find kiali-ossm subscription and then use that to find the operator/csv namespace
     local operator_namespace
-    operator_namespace=$(kubectl get subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.metadata.name=="kiali-ossm")].metadata.namespace}')
+    operator_namespace=$(oc get subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.metadata.name=="kiali-ossm")].metadata.namespace}')
     local operator_name
-    operator_name=$(kubectl get csv -n "$operator_namespace" -o jsonpath='{.items[*].metadata.name}' | awk '{ if (index($1, "kiali-operator") != 0) print $1 }')
+    operator_name=$(oc get csv -n "$operator_namespace" -o jsonpath='{.items[*].metadata.name}' | awk '{ if (index($1, "kiali-operator") != 0) print $1 }')
     local operator_version
-    operator_version=$(kubectl get csv -n "$operator_namespace" "$operator_name" -o jsonpath='{.spec.version}')
+    operator_version=$(oc get csv -n "$operator_namespace" "$operator_name" -o jsonpath='{.spec.version}')
     if [ "$operator_version" != "$LATEST_KIALI_VERSION" ]; then
         add_warning "Your Kiali operator is not on the latest version. Current version: '$operator_version'. Latest version: '$LATEST_KIALI_VERSION'. Please upgrade your Kiali operator to the latest version."
     fi
@@ -275,7 +275,7 @@ check_kialis() {
 check_istio_crds() {
     print_section "Istio CRDs"
     # Assumes that if any one of the CRDs has a v1 then the rest do.
-    if [ "$(kubectl get crds -l chart=istio -o json | jq '.items[] | select(.spec.versions[].name == "v1") | .metadata.name')" == "" ]; then
+    if [ "$(oc get crds -l chart=istio -o json | jq '.items[] | select(.spec.versions[].name == "v1") | .metadata.name')" == "" ]; then
         add_warning "v1 istio CRDs not found. Ensure you have installed the OpenShift Service Mesh 3 operator."
     fi
 }

--- a/docs/ossm/ossm2-migration/migration-checker.sh
+++ b/docs/ossm/ossm2-migration/migration-checker.sh
@@ -248,10 +248,11 @@ check_kialis() {
         echo "Kiali CRD is not detected. Skipping Kiali checks..."
         return
     fi
-    # Find smcps and check each one.
+
+    # Find kialis and check each one.
     # Format is name/namespace.
-    for smcp in $(oc get kiali -A -o jsonpath='{range .items[*]}{.metadata.name}/{.metadata.namespace}{" "}{end}'); do
-        IFS="/" read -r name namespace <<< "$smcp"
+    for kiali in $(oc get kiali -A -o jsonpath='{range .items[*]}{.metadata.name}/{.metadata.namespace}{" "}{end}'); do
+        IFS="/" read -r name namespace <<< "$kiali"
         check_kiali "$name" "$namespace"
     done
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Adds checks for Kiali and Kiali operator versions as well as the Istio CRD versions to the migration checker script. Also does some refactoring to consolidate warning checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
