### PR TITLE
[doc] Update quickstart to use tempo directly in kiali instead of jaeger in tempo

### DIFF
--- a/docs/ossm/quickstarts/ossm3-kiali-tempo-bookinfo/resources/Kiali/kialiCr.yaml
+++ b/docs/ossm/quickstarts/ossm3-kiali-tempo-bookinfo/resources/Kiali/kialiCr.yaml
@@ -39,10 +39,13 @@ spec:
       url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
     tracing:
       enabled: true
-      internal_url: "http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16685"
+      internal_url: "http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:3200"
       external_url: ${JAEGERROUTE} 
       query_timeout: 60
-      use_grpc: true
+      use_grpc: false
+      provider: tempo
+      tempo_config:
+        url_format: "jaeger"
   installation_tag: "Kiali [istio-system]"
   istio_namespace: istio-system
   server:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [x] Documentation Update

#### What this PR does / why we need it:
The quickstart uses Jaeger in tempo in Kiali CR (that way is used in OSSM 2.6 since kiali v1.73 didn't support Tempo natively and I didn't realize that the new kiali version support tempo) instead of tempo directly (as also our prod doc describes). 