### PR TITLE
OSSM-8701: List recommendations for migration

### DIFF
--- a/docs/ossm/ossm2-migration/README.md
+++ b/docs/ossm/ossm2-migration/README.md
@@ -9,6 +9,7 @@ Before you begin to migrate your controlplane from OpenShift Service Mesh 2.6 to
 - Read through the key OSSM 2.6 vs 3.0 Differences [document](./../ossm2-vs-ossm3.md) 
 - Upgrade your 2.6 OpenShift Service Mesh Operator to the latest release. See warning below.
 - Upgrade your `ServiceMeshControlPlane` version to the latest OpenShift Service Mesh release.
+- Read through the [recommendations](./possible-problems-list/README.md) before the migration.
 - Install your 3.0 Openshift Service Mesh Operator. See warning below.
 - Upgrade your Kiali operator to the latest release.
 - Disable the following features on your `ServiceMeshControlPlane`. These fields are unsupported in 3.0 and must be disabled prior to migration.

--- a/docs/ossm/ossm2-migration/possible-problems-list/README.md
+++ b/docs/ossm/ossm2-migration/possible-problems-list/README.md
@@ -9,7 +9,7 @@ Following are recommendations to keep the risk of misconfigurations or possible 
     After the OpenShift Service Mesh 3 operator is installed and migration of data plane is in progress, it's not recommended to upgrade OpenShift Service Mesh 2 operator or control planes. This can be achieved by switching from `Automatic` Operator Update approval to `Manual`.
 1. Keep the amount of the service mesh configuration changes to minimum during the migration
 
-    It's not recommended to change Istio resources for traffic management or security or add new workloads to the service mesh in the middle of the migration.
+    It's not recommended to change Istio resources for traffic management or security or add new workloads or gateways to the service mesh in the middle of the migration.
 1. Finish the migration without unnecessary delays
 
     To easier follow the recommendations above, when started the migration should be finished as soon as possible without unnecessary delays.

--- a/docs/ossm/ossm2-migration/possible-problems-list/README.md
+++ b/docs/ossm/ossm2-migration/possible-problems-list/README.md
@@ -1,0 +1,15 @@
+# OpenShift Service Mesh 2 --> 3 Migration risks and recommendations
+Given the nature of the migration (not upgrading the operator but migrating to brand new operator), there are a few problems which can't be handled by any of the OpenShift Service Mesh 2 or OpenShift Service Mesh 3 operators. We are listing those problems and recommendations here so users can prepare in advance.
+
+## Recommendations
+Following are recommendations to keep the risk of misconfigurations or possible conflicts to minimum.
+
+1. Do not upgrade OpenShift Service Mesh 2 operator or control planes in the middle of the migration
+
+    After the OpenShift Service Mesh 3 operator is installed and migration of data plane is in progress, it's not recommended to upgrade OpenShift Service Mesh 2 operator or control planes. This can be achieved by switching from `Automatic` Operator Update approval to `Manual`.
+1. Keep the amount of the service mesh configuration changes to minimum during the migration
+
+    It's not recommended to change Istio resources for traffic management or security or add new workloads to the service mesh in the middle of the migration.
+1. Finish the migration without unnecessary delays
+
+    To easier follow the recommendations above, when started the migration should be finished as soon as possible without unnecessary delays.

--- a/docs/ossm/ossm2-migration/possible-problems-list/README.md
+++ b/docs/ossm/ossm2-migration/possible-problems-list/README.md
@@ -13,4 +13,4 @@ Following are recommendations to keep the risk of misconfigurations or possible 
     > **_NOTE:_** If it's necessary to add a new workload namespace during the migration, it should be managed by 3.0 control plane and it MUST be labeled with `maistra.io/ignore-namespace: "true"` to avoid conflicts between 3.0 and 2.6 control planes.
 1. Finish the migration without unnecessary delays
 
-    To easier follow the recommendations above, when started the migration should be finished as soon as possible without unnecessary delays.
+Once the migration is started, it should be completed as quickly as possible without unnecessary delays.

--- a/docs/ossm/ossm2-migration/possible-problems-list/README.md
+++ b/docs/ossm/ossm2-migration/possible-problems-list/README.md
@@ -10,6 +10,7 @@ Following are recommendations to keep the risk of misconfigurations or possible 
 1. Keep the amount of the service mesh configuration changes to minimum during the migration
 
     It's not recommended to change Istio resources for traffic management or security or add new workloads or gateways to the service mesh in the middle of the migration.
+    > **_NOTE:_** If it's necessary to add a new workload namespace during the migration, it should be managed by 3.0 control plane and it MUST be labeled with `maistra.io/ignore-namespace: "true"` to avoid conflicts between 3.0 and 2.6 control planes.
 1. Finish the migration without unnecessary delays
 
     To easier follow the recommendations above, when started the migration should be finished as soon as possible without unnecessary delays.


### PR DESCRIPTION
Original idea for this document was to list known issues for migration but the problem with OSSM 2 operator overwriting istio CRDs was not confirmed and the problem with conflict on validating web hook will be fixed in 2.6. So there is nothing to document. I included at least recommendations which we might want to include.