### PR TITLE
Fix skipping upgrade tests when only one istio version is specified

### DIFF
--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -41,10 +41,6 @@ var _ = Describe("Control Plane updates", Label("update"), Ordered, func() {
 	debugInfoLogged := false
 
 	Describe("using IstioRevisionTag", func() {
-		if len(istioversion.List) < 2 {
-			Skip("Skipping update tests because there are not enough versions in versions.yaml")
-		}
-
 		// istioversion.Old is the version second version in versions.yaml file and istioversion.New is the first version in the List
 		// istioversion.Old is going to be the base version from where we are going to update to istioversion.New
 		// TODO: improve this: https://github.com/istio-ecosystem/sail-operator/issues/681
@@ -52,6 +48,10 @@ var _ = Describe("Control Plane updates", Label("update"), Ordered, func() {
 		newVersion := istioversion.New
 		Context(baseVersion, func() {
 			BeforeAll(func(ctx SpecContext) {
+				if len(istioversion.List) < 2 {
+					Skip("Skipping update tests because there are not enough versions in versions.yaml")
+				}
+
 				Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 				Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

When running the tests with only a single supported version in versions.yaml, they would panic during test tree construction phase due to the call to `Skip`. Moved the call  to `BeforeAll` which correctly skips the upgrade tests.