### PR TITLE
Adding spec.replaces field to CSV to allow upgrades between channels

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: quay.io/maistra-dev/sail-operator:3.0-latest
-    createdAt: "2025-04-07T08:32:09Z"
+    createdAt: "2025-04-11T05:48:42Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure,
       and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service
       Mesh is based on the open source Istio project.
@@ -788,4 +788,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc.
+  replaces: servicemeshoperator3.v3.0.0
   version: 3.0.1

--- a/chart/templates/olm/clusterserviceversion.yaml
+++ b/chart/templates/olm/clusterserviceversion.yaml
@@ -60,4 +60,5 @@ spec:
   provider:
     name: Red Hat, Inc.
   version: {{ .Values.csv.version }}
+  replaces: {{ .Values.name }}.v{{ .Values.csv.replacesVersion }}
 {{ end }}

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -68,6 +68,7 @@ csv:
     * [Bugs](https://issues.redhat.com/projects/OSSM)
   support: Red Hat, Inc.
   version: 3.0.1
+  replacesVersion: 3.0.0
   keywords:
   - istio
   - servicemesh


### PR DESCRIPTION
We are using semver operator versions which are assuring upgrades without a need for spec.replaces field but only within the same OLM channel. We will have multiplne OLM channels (one for each minor version) so it's necessary to use spec.replaces field.

For next z release, we should consider using olm.skipRange to skip all previous z releases as described in https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/how-to-update-operators.md#z-stream-support

 