### PR TITLE
Replace downstream images with environment variables

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -625,7 +625,7 @@ bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and
 	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
 		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
 	fi; \
-	$(HELM) template chart chart $$TEMPL_FLAGS --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
 ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -625,7 +625,7 @@ bundle: gen-all-except-bundle helm operator-sdk ## Generate bundle manifests and
 	if [ "$(OPENSHIFT_PLATFORM)" = "true" ]; then \
 		TEMPL_FLAGS="$$TEMPL_FLAGS --set platform=openshift"; \
 	fi; \
-	$(HELM) template chart chart $$TEMPL_FLAGS --set image='$(IMAGE)' --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(HELM) template chart chart $$TEMPL_FLAGS --set bundleGeneration=true | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 
 ifeq ($(GENERATE_RELATED_IMAGES), true)
 	@hack/patch-csv.sh bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml

--- a/Makefile.vendor.mk
+++ b/Makefile.vendor.mk
@@ -6,6 +6,7 @@ DEFAULT_CHANNEL=stable
 HELM_VALUES_FILE = ossm/values.yaml
 VERSIONS_YAML_FILE ?= versions.ossm.yaml
 GENERATE_RELATED_IMAGES = false
+IMAGE = $$\{OSSM_OPERATOR_3_1\}
 
 .PHONY: build-fips
 build-fips: ## Build sail-operator binary for FIPS mode.

--- a/Makefile.vendor.mk
+++ b/Makefile.vendor.mk
@@ -1,12 +1,11 @@
 VERSION = 3.1.0
 OPERATOR_NAME = servicemeshoperator3
-HUB = quay.io/maistra-dev
 CHANNELS = "stable,stable-3.1"
 DEFAULT_CHANNEL=stable
 HELM_VALUES_FILE = ossm/values.yaml
 VERSIONS_YAML_FILE ?= versions.ossm.yaml
 GENERATE_RELATED_IMAGES = false
-IMAGE = $$\{OSSM_OPERATOR_3_1\}
+IMAGE ?= $$\{OSSM_OPERATOR_3_1\}
 
 .PHONY: build-fips
 build-fips: ## Build sail-operator binary for FIPS mode.

--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -33,8 +33,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
-    containerImage: quay.io/maistra-dev/sail-operator:3.1.0
-    createdAt: "2025-07-08T06:34:05Z"
+    containerImage: ${OSSM_OPERATOR_3_1}
+    createdAt: "2025-07-07T10:48:37Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure,
       and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service
       Mesh is based on the open source Istio project.
@@ -700,11 +700,11 @@ spec:
                 images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:a65efcf516c6ee950f89f52d3d41dd370aa32cda622198cd477052bf8d21ba50
                 images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a5748d50850784dd9c8e6646f5caf00c52deb4397632f02ffae5c879236d3b6c
                 images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:b74f037d9e0ee57d669d6860e327340f23a752cbf598cafb7de715464b90e465
-                images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9:1.26.2
-                images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9:1.25.2
-                images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9:3.1.0
-                images.v1_26_2.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9:1.26.2
-                images.v1_26_2.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9:1.26.2
+                images.v1_26_2.cni: ${ISTIO_CNI_1_26}
+                images.v1_26_2.istiod: ${ISTIO_PILOT_1_26}
+                images.v1_26_2.must-gather: ${OSSM_MUST_GATHER_3_1}
+                images.v1_26_2.proxy: ${ISTIO_PROXY_1_26}
+                images.v1_26_2.ztunnel: ${ISTIO_ZTUNNEL_1_26}
                 kubectl.kubernetes.io/default-container: sail-operator
               labels:
                 app.kubernetes.io/created-by: servicemeshoperator3
@@ -734,7 +734,7 @@ spec:
                 - --zap-log-level=info
                 command:
                 - /sail-operator
-                image: quay.io/maistra-dev/sail-operator:3.1.0
+                image: ${OSSM_OPERATOR_3_1}
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_1}
-    createdAt: "2025-07-07T10:48:37Z"
+    createdAt: "2025-07-07T10:50:48Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure,
       and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service
       Mesh is based on the open source Istio project.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,7 @@ csv:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
-image: quay.io/maistra-dev/sail-operator:3.1.0
+image: ${OSSM_OPERATOR_3_1}
 # We're commenting out the imagePullPolicy to use k8s defaults
 # imagePullPolicy: Always
 operator:

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -1,5 +1,4 @@
 name: servicemeshoperator3
-image: ${OSSM_OPERATOR_3_1}
 deployment:
   name: servicemesh-operator3
   annotations:

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -1,4 +1,5 @@
 name: servicemeshoperator3
+image: ${OSSM_OPERATOR_3_1}
 deployment:
   name: servicemesh-operator3
   annotations:
@@ -23,11 +24,11 @@ deployment:
     images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a5748d50850784dd9c8e6646f5caf00c52deb4397632f02ffae5c879236d3b6c
     images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:b74f037d9e0ee57d669d6860e327340f23a752cbf598cafb7de715464b90e465
     # 1.26.2 images will be hardcoded to versions released with 3.1.0
-    images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9:1.26.2
-    images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9:1.25.2
-    images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9:3.1.0
-    images.v1_26_2.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9:1.26.2
-    images.v1_26_2.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9:1.26.2
+    images.v1_26_2.cni: ${ISTIO_CNI_1_26}
+    images.v1_26_2.istiod: ${ISTIO_PILOT_1_26}
+    images.v1_26_2.must-gather: ${OSSM_MUST_GATHER_3_1}
+    images.v1_26_2.proxy: ${ISTIO_PROXY_1_26}
+    images.v1_26_2.ztunnel: ${ISTIO_ZTUNNEL_1_26}
 service:
   port: 8443
 serviceAccountName: servicemesh-operator3


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [X] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

This PR refactors the image configuration system to use environment variables instead of hardcoded image references, improving build flexibility and configuration management for OpenShift Service Mesh 3.1.0 in Konflux build platform.

I have removed the `--set image='$(IMAGE)'` override from the Helm template command to allow the bundle generation to use image values from the values.yaml file instead of being overridden by Makefile variables.
