### PR TITLE
[3.0.4] Prepare placeholders for OSSM 3.0.4 release without istio changes

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_0}
-    createdAt: "2025-07-11T06:53:36Z"
+    createdAt: "2025-08-18T09:09:28Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -651,11 +651,11 @@ spec:
                   images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
                   images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
                   images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-                  images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2823e8562b11ca0b2ebed4443bc2f9c3ba04e1658173e929e6ce0c7eb791e296
-                  images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:a65efcf516c6ee950f89f52d3d41dd370aa32cda622198cd477052bf8d21ba50
-                  images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:52ae43bdf009c522c2b43493977bb7f211d436bd4776f283b34ca7b5c7a87094
-                  images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a5748d50850784dd9c8e6646f5caf00c52deb4397632f02ffae5c879236d3b6c
-                  images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:b74f037d9e0ee57d669d6860e327340f23a752cbf598cafb7de715464b90e465
+                  images.v1_24_6.cni: ${ISTIO_CNI_1_24}
+                  images.v1_24_6.istiod: ${ISTIO_PILOT_1_24}
+                  images.v1_24_6.must-gather: ${OSSM_MUST_GATHER_3_0}
+                  images.v1_24_6.proxy: ${ISTIO_PROXY_1_24}
+                  images.v1_24_6.ztunnel: ${ISTIO_PROXY_1_24}
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: servicemeshoperator3

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -18,11 +18,11 @@ deployment:
     images.v1_24_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54cada48e5c9824f255f82daa2ef5bea236919e521d3ea49885f2883ced2b7bc
     images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
     # 1.24.6 images are hardcoded to versions released with 3.0.3
-    images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:a65efcf516c6ee950f89f52d3d41dd370aa32cda622198cd477052bf8d21ba50
-    images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a5748d50850784dd9c8e6646f5caf00c52deb4397632f02ffae5c879236d3b6c
-    images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2823e8562b11ca0b2ebed4443bc2f9c3ba04e1658173e929e6ce0c7eb791e296
-    images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:b74f037d9e0ee57d669d6860e327340f23a752cbf598cafb7de715464b90e465
-    images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:52ae43bdf009c522c2b43493977bb7f211d436bd4776f283b34ca7b5c7a87094
+    images.v1_24_6.istiod: ${ISTIO_PILOT_1_24}
+    images.v1_24_6.proxy: ${ISTIO_PROXY_1_24}
+    images.v1_24_6.cni: ${ISTIO_CNI_1_24}
+    images.v1_24_6.ztunnel: ${ISTIO_PROXY_1_24}
+    images.v1_24_6.must-gather: ${OSSM_MUST_GATHER_3_0}
     # for unreleased downstream images, use env variables as placeholders, i.e.: images.v1_26_2.cni: ${ISTIO_CNI_1_26}
 service:
   port: 8443


### PR DESCRIPTION
Prepare placeholders for 3.0.4 release.
There is no new Istio version, so the images for 1.24.6 will be updated
