### PR TITLE
Revert "Adding support for configuring the max concurrent reconciles (#1139)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,8 +56,6 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&configFile, "config-file", "/etc/sail-operator/config.properties", "Location of the config file, propagated by k8s downward APIs")
 	flag.StringVar(&reconcilerCfg.ResourceDirectory, "resource-directory", "/var/lib/sail-operator/resources", "Where to find resources (e.g. charts)")
-	flag.IntVar(&reconcilerCfg.MaxConcurrentReconciles, "max-concurrent-reconciles", 5,
-		"MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.")
 	flag.BoolVar(&logAPIRequests, "log-api-requests", false, "Whether to log each request sent to the Kubernetes API server")
 	flag.BoolVar(&printVersion, "version", printVersion, "Prints version information and exits")
 	flag.BoolVar(&leaderElectionEnabled, "leader-elect", true,
@@ -200,7 +198,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = webhook.NewReconciler(reconcilerCfg, mgr.GetClient(), mgr.GetScheme()).
+	err = webhook.NewReconciler(mgr.GetClient(), mgr.GetScheme()).
 		SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Endpoints")

--- a/controllers/istio/istio_controller.go
+++ b/controllers/istio/istio_controller.go
@@ -209,7 +209,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
-			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
 		// +lint-watches:ignore: Istio (not found in charts, but this is the main resource watched by this controller)

--- a/controllers/istio/istio_controller_test.go
+++ b/controllers/istio/istio_controller_test.go
@@ -1091,9 +1091,8 @@ func noWrites(t *testing.T) interceptor.Funcs {
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 	return config.ReconcilerConfig{
-		ResourceDirectory:       t.TempDir(),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		ResourceDirectory: t.TempDir(),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
 	}
 }

--- a/controllers/istiocni/istiocni_controller.go
+++ b/controllers/istiocni/istiocni_controller.go
@@ -234,7 +234,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
-			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged

--- a/controllers/istiocni/istiocni_controller_test.go
+++ b/controllers/istiocni/istiocni_controller_test.go
@@ -705,9 +705,8 @@ func normalize(condition v1.IstioCNICondition) v1.IstioCNICondition {
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 	return config.ReconcilerConfig{
-		ResourceDirectory:       t.TempDir(),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		ResourceDirectory: t.TempDir(),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
 	}
 }

--- a/controllers/istiorevision/istiorevision_controller.go
+++ b/controllers/istiorevision/istiorevision_controller.go
@@ -240,7 +240,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
-			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
 		// +lint-watches:ignore: IstioRevision (not found in charts, but this is the main resource watched by this controller)

--- a/controllers/istiorevision/istiorevision_controller_test.go
+++ b/controllers/istiorevision/istiorevision_controller_test.go
@@ -896,9 +896,8 @@ func TestIgnoreStatusChangePredicate(t *testing.T) {
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 	return config.ReconcilerConfig{
-		ResourceDirectory:       t.TempDir(),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		ResourceDirectory: t.TempDir(),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
 	}
 }

--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -263,7 +263,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
-			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged
 		Watches(&v1.IstioRevisionTag{}, mainObjectHandler).

--- a/controllers/istiorevisiontag/istiorevisiontag_controller_test.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller_test.go
@@ -277,10 +277,9 @@ func TestDetermineInUseCondition(t *testing.T) {
 
 func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
 	return config.ReconcilerConfig{
-		ResourceDirectory:       t.TempDir(),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
+		ResourceDirectory: t.TempDir(),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
 	}
 }
 

--- a/controllers/webhook/webhook_controller.go
+++ b/controllers/webhook/webhook_controller.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/go-logr/logr"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
-	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/constants"
 	"github.com/istio-ecosystem/sail-operator/pkg/enqueuelogger"
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
@@ -55,15 +54,13 @@ var customDialContext func(ctx context.Context, network, addr string) (net.Conn,
 
 // Reconciler checks the readiness of MutatingWebhookConfiguration pointing to a remote Istio control plane
 type Reconciler struct {
-	Config config.ReconcilerConfig
 	client.Client
 	Scheme *runtime.Scheme
 	probe  func(context.Context, *admissionv1.MutatingWebhookConfiguration) (bool, error)
 }
 
-func NewReconciler(cfg config.ReconcilerConfig, client client.Client, scheme *runtime.Scheme) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme) *Reconciler {
 	return &Reconciler{
-		Config: cfg,
 		Client: client,
 		Scheme: scheme,
 		probe:  doProbe,
@@ -184,7 +181,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}
 				return log
 			},
-			MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles,
 		}).
 
 		// we use the Watches function instead of For(), so that we can wrap the handler so that events that cause the object to be enqueued are logged

--- a/controllers/webhook/webhook_controller_test.go
+++ b/controllers/webhook/webhook_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
-	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/constants"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
 	"github.com/istio-ecosystem/sail-operator/pkg/scheme"
@@ -129,7 +128,7 @@ func TestReconcile(t *testing.T) {
 				WithObjects(webhook).
 				WithInterceptorFuncs(tt.interceptors).
 				Build()
-			r := NewReconciler(newReconcilerTestConfig(t), cl, scheme.Scheme)
+			r := NewReconciler(cl, scheme.Scheme)
 			r.probe = tt.probeFunc
 
 			result, err := r.Reconcile(ctx, webhook)
@@ -611,13 +610,4 @@ func generateSelfSignedCert(dnsNames ...string) (certPEM []byte, keyPEM []byte, 
 	})
 
 	return certPEM, keyPEM, nil
-}
-
-func newReconcilerTestConfig(t *testing.T) config.ReconcilerConfig {
-	return config.ReconcilerConfig{
-		ResourceDirectory:       t.TempDir(),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		MaxConcurrentReconciles: 5,
-	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,11 +34,10 @@ type IstioImageConfig struct {
 }
 
 type ReconcilerConfig struct {
-	ResourceDirectory       string
-	Platform                Platform
-	DefaultProfile          string
-	OperatorNamespace       string
-	MaxConcurrentReconciles int
+	ResourceDirectory string
+	Platform          Platform
+	DefaultProfile    string
+	OperatorNamespace string
 }
 
 func Read(configFile string) error {

--- a/tests/integration/api/suite_test.go
+++ b/tests/integration/api/suite_test.go
@@ -87,11 +87,10 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient.Create(context.TODO(), operatorNs)).To(Succeed())
 
 	cfg := config.ReconcilerConfig{
-		ResourceDirectory:       path.Join(project.RootDir, "resources"),
-		Platform:                config.PlatformKubernetes,
-		DefaultProfile:          "",
-		OperatorNamespace:       operatorNs.Name,
-		MaxConcurrentReconciles: 5,
+		ResourceDirectory: path.Join(project.RootDir, "resources"),
+		Platform:          config.PlatformKubernetes,
+		DefaultProfile:    "",
+		OperatorNamespace: operatorNs.Name,
 	}
 
 	cl := mgr.GetClient()


### PR DESCRIPTION
This reverts commit 1e02653e847140d30a2b2740c85c8dca14278cfd from 3.1.1 release branch (only)

