### PR TITLE
[release-3.1] Update istio module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,4 +188,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace istio.io/istio => github.com/openshift-service-mesh/istio v0.0.0-20250820174634-270914da554f
+replace istio.io/istio => github.com/openshift-service-mesh/istio v0.0.0-20250909123806-66714d7c0ee6

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openshift-service-mesh/istio v0.0.0-20250820174634-270914da554f h1:DND21XspLiQPJtuoWm0McYPWbkEJCjri4CB3dWwBbWY=
-github.com/openshift-service-mesh/istio v0.0.0-20250820174634-270914da554f/go.mod h1:Ydt/C1QMjZreUvVVIIq3YJSJ0b2TELnClRVzGFONcMM=
+github.com/openshift-service-mesh/istio v0.0.0-20250909123806-66714d7c0ee6 h1:b9ZrEW9dWg3uwPSD1MeZOmp8MA8L9m7vyKQI3H1WiFQ=
+github.com/openshift-service-mesh/istio v0.0.0-20250909123806-66714d7c0ee6/go.mod h1:8IKCq+C9AMONPqmnEav7pYMRoM6eaH46PFey0yBtEds=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=


### PR DESCRIPTION
Update istio module after istio 1.26.4 update in istio repo
```
go mod edit -replace="istio.io/istio=github.com/openshift-service-mesh/istio@release-1.26";go mod tidy
```