### PR TITLE
OSSM-10899: updating migration documentation for pod level annotations

### DIFF
--- a/docs/ossm/ossm2-migration/cleaning-2.6/README.md
+++ b/docs/ossm/ossm2-migration/cleaning-2.6/README.md
@@ -25,6 +25,7 @@ When the migration of all workloads is finished, it's possible to remove OpenShi
     ```
 
 > **_NOTE:_** that depending on how you created `ServiceMeshMembers` and `ServiceMeshMemberRoll`, those resources might be removed automatically with removal of `ServiceMeshControlPlane` after step 2.
+> **_NOTE:_** OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations` and it must be set as a label instead in `metadata.labels`. Keeping the annotation is harmless but it can be also safely removed.
 
 ## Remove 2.6 operator and CRDs
 1. Make sure there are no Service Mesh 2.6 resources left:

--- a/docs/ossm/ossm2-migration/cluster-wide/README.md
+++ b/docs/ossm/ossm2-migration/cluster-wide/README.md
@@ -50,7 +50,7 @@ Going back to your OpenShift Service Mesh 2.6 installation, the way member selec
 
     With this configuration, it will be necessary to add either the `istio.io/rev` or `istio-injection` label during the migration.
 
-> **_NOTE:_** OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations`. Migration steps described bellow are adding namespace injection labels so there is no additional action required for resources using `sidecar.istio.io/inject: 'true'` annotation as the injection will be controlled by the namespace labels and `sidecar.istio.io/inject: 'true'` annotation will be ignored.
+> **_NOTE:_** OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations`. Migration steps described below are adding namespace injection labels so there is no additional action required for resources using `sidecar.istio.io/inject: 'true'` annotation as the injection will be controlled by the namespace labels and `sidecar.istio.io/inject: 'true'` annotation will be ignored.
 
 Procedures below show different approaches for migration. Only first or second procedure should be used for production environments. Read a description of each procedure to pick one which fits your needs.
 

--- a/docs/ossm/ossm2-migration/cluster-wide/README.md
+++ b/docs/ossm/ossm2-migration/cluster-wide/README.md
@@ -50,6 +50,8 @@ Going back to your OpenShift Service Mesh 2.6 installation, the way member selec
 
     With this configuration, it will be necessary to add either the `istio.io/rev` or `istio-injection` label during the migration.
 
+> **_NOTE:_** OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations`. Migration steps described bellow are adding namespace injection labels so there is no additional action required for resources using `sidecar.istio.io/inject: 'true'` annotation as the injection will be controlled by the namespace labels and `sidecar.istio.io/inject: 'true'` annotation will be ignored.
+
 Procedures below show different approaches for migration. Only first or second procedure should be used for production environments. Read a description of each procedure to pick one which fits your needs.
 
 #### Migration to 3.0 using istio.io/rev label

--- a/docs/ossm/ossm2-migration/multi-tenancy/README.md
+++ b/docs/ossm/ossm2-migration/multi-tenancy/README.md
@@ -148,6 +148,7 @@ oc create ns istio-system-tenant-a
    Now we are ready to migrate our workloads from our 2.6 controlplane to our 3.0 controlplane.
 
 #### Migrate Workloads
+> **_NOTE:_** OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations`. Migration steps described bellow are adding namespace injection labels so there is no additional action required for resources using `sidecar.istio.io/inject: 'true'` annotation as the injection will be controlled by the namespace labels and `sidecar.istio.io/inject: 'true'` annotation will be ignored.
 
 1. Find the current `IstioRevision` for your Service Mesh 3.0 controlplane.
 

--- a/docs/ossm/ossm2-vs-ossm3.md
+++ b/docs/ossm/ossm2-vs-ossm3.md
@@ -54,6 +54,8 @@ When an `Istio` resource has the name “default” and `InPlace` upgrades are u
 
 However, when an `IstioRevision` resource has a name other than “default” - as required when multiple control plane instances are present and/or when using the `RevisionBased` update strategy, it might be necessary to use a label that indicates which control plane (revision) the workload(s) belong to - namely, `istio.io/rev=<IstioRevision-name>`. These labels may be applied at the workload or namespace level. Available revisions may be inspected with the command `oc get istiorevision`. In order to use the `istio-injection=enabled` in combination with `RevisionBased` deployments, it is possible to create an `IstioRevisionTag` resource that is named `default`, see the [`IstioRevisionTag`](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/api-reference/sailoperator.io.md#istiorevisiontag) documentation for more information.
 
+OpenShift Service Mesh 3.0 does not support `sidecar.istio.io/inject: 'true'` annotation on a pod in `metadata.annotations` and it must be set as a label instead in `metadata.labels`.
+
 ## Multiple Control Plane Support
 
 OpenShift Service Mesh 3 supports multiple service meshes in the same cluster, but in a different manner than in OpenShift Service Mesh 2. A cluster administrator must create multiple `Istio` instances and then configure `discoverySelectors` appropriately to ensure that there is no overlap between mesh namespaces. 


### PR DESCRIPTION
Adding notes about pod level injection annotations which are not supported in OSSM 3.0

 