### PR TITLE
[3.3.2] Prepare placeholders for 3.3.2 release without Istio changes.

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_3}
-    createdAt: "2026-03-27T13:42:32Z"
+    createdAt: "2026-04-08T11:39:09Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -729,11 +729,11 @@ spec:
                   images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
                   images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
                   images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
-                  images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
-                  images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
-                  images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
-                  images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
-                  images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
+                  images.v1_26_8.cni: ${ISTIO_CNI_1_26}
+                  images.v1_26_8.istiod: ${ISTIO_PILOT_1_26}
+                  images.v1_26_8.must-gather: ${OSSM_MUST_GATHER_3_1}
+                  images.v1_26_8.proxy: ${ISTIO_PROXY_1_26}
+                  images.v1_26_8.ztunnel: ${ISTIO_ZTUNNEL_1_26}
                   images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
                   images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
                   images.v1_27_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:742bc084c26769ff57cb3aa47b7a35c2b94684c3f67a9388da07a0490a942e5c
@@ -744,21 +744,21 @@ spec:
                   images.v1_27_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d1baba8cb454b62d804dc427d4ccfea928348631c384d1ab3d170e1e2a9d1178
                   images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
                   images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
-                  images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
-                  images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
-                  images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
-                  images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
-                  images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
+                  images.v1_27_8.cni: ${ISTIO_CNI_1_27}
+                  images.v1_27_8.istiod: ${ISTIO_PILOT_1_27}
+                  images.v1_27_8.must-gather: ${OSSM_MUST_GATHER_3_2}
+                  images.v1_27_8.proxy: ${ISTIO_PROXY_1_27}
+                  images.v1_27_8.ztunnel: ${ISTIO_ZTUNNEL_1_27}
                   images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
                   images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
                   images.v1_28_4.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d57d23fc8ec4053a3d819ffb87532d6aec6b5874fdf22e22afdd7f0f0712df52
                   images.v1_28_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ba78d718627a0662f61ec633fdd2867ba5c24be6bdbc6df672d46456fb399dba
                   images.v1_28_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:2d5a3154e7b6b8d7eadb851a86cc5b7ee556b923843e73ae56197e875c564b03
-                  images.v1_28_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6167fbd27225658213894efcad7eaa172415873ef89c2239e5dd1d18ee15e362
-                  images.v1_28_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:4813bf7ae960860d28b5ab7b493ce10f1879e3276b1b64732299a9750737bcfd
-                  images.v1_28_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:eb58878893732fb5324ccbd07f2c34f85d977ad7067827dc114c14ed2d50dc57
-                  images.v1_28_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:bc34f81266d8b0d2f5a8e71e966098d4edef70ac8dbb077a014a27fe1b71ec0a
-                  images.v1_28_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:93dddaa0db0510d8c3bbf3376ca49311dd28ac644aa5dfcb3f5888ace89840a4
+                  images.v1_28_5.cni: ${ISTIO_CNI_1_28}
+                  images.v1_28_5.istiod: ${ISTIO_PILOT_1_28}
+                  images.v1_28_5.must-gather: ${OSSM_MUST_GATHER_3_3}
+                  images.v1_28_5.proxy: ${ISTIO_PROXY_1_28}
+                  images.v1_28_5.ztunnel: ${ISTIO_ZTUNNEL_1_28}
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: servicemeshoperator3

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -29,11 +29,11 @@ deployment:
     images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
     images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
     # 1.26.8 images
-    images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
-    images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
-    images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
-    images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
-    images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
+    images.v1_26_8.cni: ${ISTIO_CNI_1_26}
+    images.v1_26_8.istiod: ${ISTIO_PILOT_1_26}
+    images.v1_26_8.must-gather: ${OSSM_MUST_GATHER_3_1}
+    images.v1_26_8.proxy: ${ISTIO_PROXY_1_26}
+    images.v1_26_8.ztunnel: ${ISTIO_ZTUNNEL_1_26}
     # 1.27.3 images
     images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
     images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
@@ -47,11 +47,11 @@ deployment:
     images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
     images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
     # 1.27.8 images will be replaced with Konflux built images and will be updated after 3.2.3 release
-    images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
-    images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
-    images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
-    images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
-    images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
+    images.v1_27_8.cni: ${ISTIO_CNI_1_27}
+    images.v1_27_8.istiod: ${ISTIO_PILOT_1_27}
+    images.v1_27_8.must-gather: ${OSSM_MUST_GATHER_3_2}
+    images.v1_27_8.proxy: ${ISTIO_PROXY_1_27}
+    images.v1_27_8.ztunnel: ${ISTIO_ZTUNNEL_1_27}
     # 1.28.4 images after 3.3.0 GA
     images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
     images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
@@ -59,11 +59,11 @@ deployment:
     images.v1_28_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ba78d718627a0662f61ec633fdd2867ba5c24be6bdbc6df672d46456fb399dba
     images.v1_28_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:2d5a3154e7b6b8d7eadb851a86cc5b7ee556b923843e73ae56197e875c564b03
     # 1.28.5 images will be replaced with Konflux built images and will be updated after 3.3.1 release
-    images.v1_28_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6167fbd27225658213894efcad7eaa172415873ef89c2239e5dd1d18ee15e362
-    images.v1_28_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:4813bf7ae960860d28b5ab7b493ce10f1879e3276b1b64732299a9750737bcfd
-    images.v1_28_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:eb58878893732fb5324ccbd07f2c34f85d977ad7067827dc114c14ed2d50dc57
-    images.v1_28_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:bc34f81266d8b0d2f5a8e71e966098d4edef70ac8dbb077a014a27fe1b71ec0a
-    images.v1_28_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:93dddaa0db0510d8c3bbf3376ca49311dd28ac644aa5dfcb3f5888ace89840a4
+    images.v1_28_5.cni: ${ISTIO_CNI_1_28}
+    images.v1_28_5.istiod: ${ISTIO_PILOT_1_28}
+    images.v1_28_5.must-gather: ${OSSM_MUST_GATHER_3_3}
+    images.v1_28_5.proxy: ${ISTIO_PROXY_1_28}
+    images.v1_28_5.ztunnel: ${ISTIO_ZTUNNEL_1_28}
 service:
   port: 8443
 serviceAccountName: servicemesh-operator3


### PR DESCRIPTION
Replace hardcoded v1_26_8, v1_27_8, and v1_28_5 images with ENV placeholders as there is no new Istio version.