### PR TITLE
Fix serves metrics securely test

### DIFF
--- a/tests/e2e/operator/operator_install_test.go
+++ b/tests/e2e/operator/operator_install_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
@@ -94,11 +95,14 @@ var _ = Describe("Operator", Label("smoke", "operator"), Ordered, func() {
 		})
 
 		It("serves metrics securely", func(ctx SpecContext) {
-			metricsReaderRoleName := "sailoperator-metrics-reader"
+			By("discovering the metrics reader ClusterRole installed on the cluster")
+			metricsReaderRoleName, err := discoverMetricsReaderClusterRole()
+			Expect(err).NotTo(HaveOccurred(), "metrics reader ClusterRole must exist")
+
 			metricsServiceName := deploymentName + "-metrics-service"
 
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			err := k.CreateFromString(fmt.Sprintf(`
+			err = k.CreateFromString(fmt.Sprintf(`
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -205,6 +209,39 @@ func extractCRDNames(crdList *apiextensionsv1.CustomResourceDefinitionList) []st
 		names = append(names, crd.ObjectMeta.Name)
 	}
 	return names
+}
+
+const metricsReaderClusterRoleLabel = "app.kubernetes.io/component=kube-rbac-proxy"
+
+// discoverMetricsReaderClusterRole lists ClusterRoles with the kube-rbac-proxy component label
+// (same as chart/bundle), then picks the one whose name ends with "-metrics-reader".
+func discoverMetricsReaderClusterRole() (string, error) {
+	out, err := k.GetClusterRoleNamesByLabel(metricsReaderClusterRoleLabel)
+	if err != nil {
+		return "", err
+	}
+	var matches []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name := line
+		if i := strings.LastIndex(line, "/"); i >= 0 {
+			name = line[i+1:]
+		}
+		if strings.HasSuffix(name, "-metrics-reader") {
+			matches = append(matches, name)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no *-metrics-reader ClusterRole under label %s", metricsReaderClusterRoleLabel)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous *-metrics-reader ClusterRoles: %v", matches)
+	}
 }
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -214,6 +214,17 @@ func (k Kubectl) GetYAML(kind, name string) (string, error) {
 	return output, nil
 }
 
+// GetClusterRoleNamesByLabel runs `kubectl|oc get clusterrole -l <selector> -o name` (cluster-scoped; no namespace).
+func (k Kubectl) GetClusterRoleNamesByLabel(labelSelector string) (string, error) {
+	cmd := k.build(fmt.Sprintf(" get clusterrole -l %q -o name", labelSelector))
+	output, err := k.executeCommand(cmd)
+	if err != nil {
+		return "", fmt.Errorf("error listing clusterroles: %w, output: %s", err, output)
+	}
+
+	return output, nil
+}
+
 // GetPods returns the pods of a namespace
 func (k Kubectl) GetPods(args ...string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" get pods %s", strings.Join(args, " ")))


### PR DESCRIPTION
After this change from upstream https://github.com/openshift-service-mesh/sail-operator/commit/4fa6561a660a73558924e4af66e26769eef6a5e7 the next `make gen` https://github.com/openshift-service-mesh/sail-operator/commit/b2bcc27050581fb9650bb392b6e89cf218f52dd0#diff-e014ceaac06110ab8045d17c372d729b866430398443a90fda73a179b1418400R7 changed name from `sailoperator-metrics-reader` to `servicemeshoperator3-metrics-reader` 
So, we need to adjust tests as well. 
