### PR TITLE
fix: pass nil tlsConfig to ComputeValues in pkg/install installer

### DIFF
--- a/pkg/install/installer.go
+++ b/pkg/install/installer.go
@@ -126,6 +126,7 @@ func (inst *installer) resolveValues(opts Options) (string, *v1.Values, error) {
 		"",
 		inst.resourceFS,
 		opts.Revision,
+		nil,
 	)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to compute values: %w", err)


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
The upstream commit [1b879c5b](https://github.com/istio-ecosystem/sail-operator/pull/1513) added a *config.TLSConfig parameter to `revision.ComputeValues`, extending its signature from 8 to 9 arguments. The automated sync updated all upstream tracked files (dependency.go, istio_controller.go, dependency_test.go), but missed `pkg/install/installer.go` since that file is midstream only and not visible to the sync tooling.

Passing nil as the `tlsConfig`.

Merging this will fix lint and unit test on the upstream sync PR: https://github.com/openshift-service-mesh/sail-operator/pull/793

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
