### PR TITLE
feat: use new fips 140-3-redhat policy with TLS13 support

### DIFF
--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -61,7 +61,7 @@ func ApplyFipsValues(values *v1.Values) {
 		values.Pilot.Env = make(map[string]string)
 	}
 	if _, found := values.Pilot.Env["COMPLIANCE_POLICY"]; !found {
-		values.Pilot.Env["COMPLIANCE_POLICY"] = "fips-140-2"
+		values.Pilot.Env["COMPLIANCE_POLICY"] = "fips-140-3-redhat"
 	}
 }
 

--- a/pkg/istiovalues/fips_test.go
+++ b/pkg/istiovalues/fips_test.go
@@ -80,7 +80,7 @@ func TestApplyFipsValues(t *testing.T) {
 			inputValues: &v1.Values{},
 			expectValues: &v1.Values{
 				Pilot: &v1.PilotConfig{
-					Env: map[string]string{"COMPLIANCE_POLICY": "fips-140-2"},
+					Env: map[string]string{"COMPLIANCE_POLICY": "fips-140-3-redhat"},
 				},
 			},
 		},
@@ -96,7 +96,7 @@ func TestApplyFipsValues(t *testing.T) {
 				Pilot: &v1.PilotConfig{
 					Env: map[string]string{
 						"OTHER_VAR":         "value",
-						"COMPLIANCE_POLICY": "fips-140-2",
+						"COMPLIANCE_POLICY": "fips-140-3-redhat",
 					},
 				},
 			},

--- a/pkg/revision/values_test.go
+++ b/pkg/revision/values_test.go
@@ -120,7 +120,7 @@ spec:`)), 0o644))
 
 	expected := &v1.Values{
 		Pilot: &v1.PilotConfig{
-			Env: map[string]string{"COMPLIANCE_POLICY": "fips-140-2"},
+			Env: map[string]string{"COMPLIANCE_POLICY": "fips-140-3-redhat"},
 		},
 		Global: &v1.GlobalConfig{
 			Platform:       ptr.Of("openshift"),


### PR DESCRIPTION
This way ztunnel does not need to enable TLS12 anymore.

Depends on: https://github.com/openshift-service-mesh/istio/pull/767
