### PR TITLE
Stop setting `TLS12_ENABLED` on ZTunnel for 1.30+ (#1969)

### DIFF
--- a/pkg/istiovalues/fips.go
+++ b/pkg/istiovalues/fips.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 
 	"istio.io/istio/pkg/log"
@@ -50,7 +51,7 @@ func detectFipsMode(filepath string) {
 }
 
 // ApplyFipsValues sets pilot.env.COMPLIANCE_POLICY if FIPS mode is enabled in the system.
-func ApplyFipsValues(values *v1.Values) {
+func ApplyFipsValues(values *v1.Values, version *semver.Version) {
 	if !FipsEnabled || values == nil {
 		return
 	}
@@ -60,23 +61,48 @@ func ApplyFipsValues(values *v1.Values) {
 	if values.Pilot.Env == nil {
 		values.Pilot.Env = make(map[string]string)
 	}
-	if _, found := values.Pilot.Env["COMPLIANCE_POLICY"]; !found {
-		values.Pilot.Env["COMPLIANCE_POLICY"] = "fips-140-3-redhat"
+	// For versions < 1.30, the upstream compliance policy is supported.
+	// For 1.30, the Red Hat compliance policy is required because the upstream
+	// fips-140-3 compliance policy is not supported.
+	// TODO: When the upstream fips-140-3 compliance policy is supported,
+	// migrate to using that policy.
+	if version != nil && version.LessThan(istio1_30) {
+		// TODO: Remove this after 1.29 is no longer supported.
+		if _, found := values.Pilot.Env["COMPLIANCE_POLICY"]; !found {
+			values.Pilot.Env["COMPLIANCE_POLICY"] = "fips-140-2"
+		}
+	} else {
+		if _, found := values.Pilot.Env["COMPLIANCE_POLICY"]; !found {
+			values.Pilot.Env["COMPLIANCE_POLICY"] = "fips-140-3-redhat"
+		}
 	}
 }
 
 // ApplyZTunnelFipsValues sets ztunnel.env.TLS12_ENABLED if FIPS mode is enabled in the system.
-func ApplyZTunnelFipsValues(values *v1.ZTunnelValues) {
+// For versions >= 1.30, TLS12_ENABLED is removed because ztunnel
+// defaults to using only FIPS 140-3 approved ciphers.
+func ApplyZTunnelFipsValues(values *v1.ZTunnelValues, version *semver.Version) {
 	if !FipsEnabled || values == nil {
 		return
 	}
+
 	if values.ZTunnel == nil {
 		values.ZTunnel = &v1.ZTunnelConfig{}
 	}
 	if values.ZTunnel.Env == nil {
 		values.ZTunnel.Env = make(map[string]string)
 	}
-	if _, found := values.ZTunnel.Env["TLS12_ENABLED"]; !found {
-		values.ZTunnel.Env["TLS12_ENABLED"] = "true"
+
+	// For versions < 1.30, TLS12_ENABLED is used because only
+	// fips-140-2 is supported in openshift.
+	// For 1.30, we no longer need to set TLS12_ENABLED because
+	// fips-140-3 is supported on openshift and ZTunnel will use
+	// this by default. If the user manually specifies TLS12_ENABLED,
+	// it will still be honored.
+	// TODO: Remove this after 1.29 is no longer supported.
+	if version != nil && version.LessThan(istio1_30) {
+		if _, found := values.ZTunnel.Env["TLS12_ENABLED"]; !found {
+			values.ZTunnel.Env["TLS12_ENABLED"] = "true"
+		}
 	}
 }

--- a/pkg/istiovalues/fips_test.go
+++ b/pkg/istiovalues/fips_test.go
@@ -19,14 +19,15 @@ import (
 	"path"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 )
 
 func TestDetectFipsMode(t *testing.T) {
 	resourceDir := t.TempDir()
-	os.WriteFile(path.Join(resourceDir, "fips_enabled"), []byte(("1\n")), 0o644)
-	os.WriteFile(path.Join(resourceDir, "fips_not_enabled"), []byte(("0\n")), 0o644)
+	os.WriteFile(path.Join(resourceDir, "fips_enabled"), []byte("1\n"), 0o644)
+	os.WriteFile(path.Join(resourceDir, "fips_not_enabled"), []byte("0\n"), 0o644)
 	tests := []struct {
 		name        string
 		filepath    string
@@ -65,18 +66,21 @@ func TestApplyFipsValues(t *testing.T) {
 	tests := []struct {
 		name         string
 		fipsEnabled  bool
+		version      *semver.Version
 		inputValues  *v1.Values
 		expectValues *v1.Values
 	}{
 		{
 			name:         "FIPS not enabled",
 			fipsEnabled:  false,
+			version:      semver.MustParse("1.30.0"),
 			inputValues:  &v1.Values{},
 			expectValues: &v1.Values{},
 		},
 		{
-			name:        "FIPS enabled",
+			name:        "FIPS enabled and version >= 1.30 uses fips-140-3-redhat",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.30.0"),
 			inputValues: &v1.Values{},
 			expectValues: &v1.Values{
 				Pilot: &v1.PilotConfig{
@@ -85,8 +89,20 @@ func TestApplyFipsValues(t *testing.T) {
 			},
 		},
 		{
+			name:        "FIPS enabled and version < 1.30 uses fips-140-2",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.29.0"),
+			inputValues: &v1.Values{},
+			expectValues: &v1.Values{
+				Pilot: &v1.PilotConfig{
+					Env: map[string]string{"COMPLIANCE_POLICY": "fips-140-2"},
+				},
+			},
+		},
+		{
 			name:        "FIPS enabled with existing env",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.30.0"),
 			inputValues: &v1.Values{
 				Pilot: &v1.PilotConfig{
 					Env: map[string]string{"OTHER_VAR": "value"},
@@ -104,6 +120,7 @@ func TestApplyFipsValues(t *testing.T) {
 		{
 			name:        "FIPS enabled but COMPLIANCE_POLICY already set",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.30.0"),
 			inputValues: &v1.Values{
 				Pilot: &v1.PilotConfig{
 					Env: map[string]string{"COMPLIANCE_POLICY": "custom-policy"},
@@ -118,6 +135,7 @@ func TestApplyFipsValues(t *testing.T) {
 		{
 			name:         "nil values",
 			fipsEnabled:  false,
+			version:      semver.MustParse("1.30.0"),
 			inputValues:  nil,
 			expectValues: nil,
 		},
@@ -128,7 +146,7 @@ func TestApplyFipsValues(t *testing.T) {
 			originalFipsEnabled := FipsEnabled
 			t.Cleanup(func() { FipsEnabled = originalFipsEnabled })
 			FipsEnabled = tt.fipsEnabled
-			ApplyFipsValues(tt.inputValues)
+			ApplyFipsValues(tt.inputValues, tt.version)
 
 			if diff := cmp.Diff(tt.expectValues, tt.inputValues); diff != "" {
 				t.Errorf("COMPLIANCE_POLICY env wasn't applied properly; diff (-expected, +actual):\n%v", diff)
@@ -141,18 +159,32 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 	tests := []struct {
 		name         string
 		fipsEnabled  bool
+		version      *semver.Version
 		inputValues  *v1.ZTunnelValues
 		expectValues *v1.ZTunnelValues
 	}{
 		{
 			name:         "FIPS not enabled",
 			fipsEnabled:  false,
+			version:      semver.MustParse("1.29.0"),
 			inputValues:  &v1.ZTunnelValues{},
 			expectValues: &v1.ZTunnelValues{},
 		},
 		{
 			name:        "FIPS enabled",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.29.0"),
+			inputValues: &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{"TLS12_ENABLED": "true"},
+				},
+			},
+		},
+		{
+			name:        "FIPS enabled - 1.29.1 - ensure semver comparison is correct",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.29.1"),
 			inputValues: &v1.ZTunnelValues{},
 			expectValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
@@ -163,6 +195,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:        "FIPS enabled with existing env",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.29.0"),
 			inputValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
 					Env: map[string]string{"OTHER_VAR": "value"},
@@ -180,6 +213,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:        "FIPS enabled but TLS12_ENABLED already set",
 			fipsEnabled: true,
+			version:     semver.MustParse("1.29.0"),
 			inputValues: &v1.ZTunnelValues{
 				ZTunnel: &v1.ZTunnelConfig{
 					Env: map[string]string{"TLS12_ENABLED": "false"},
@@ -194,8 +228,84 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 		{
 			name:         "nil values",
 			fipsEnabled:  false,
+			version:      semver.MustParse("1.29.0"),
 			inputValues:  nil,
 			expectValues: nil,
+		},
+		{
+			name:        "version 1.30 does not set TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.30.0"),
+			inputValues: &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{},
+				},
+			},
+		},
+		{
+			name:        "version 1.30 preserves user-specified TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.30.0"),
+			inputValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"TLS12_ENABLED": "true",
+						"OTHER_VAR":     "keep",
+					},
+				},
+			},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"TLS12_ENABLED": "true",
+						"OTHER_VAR":     "keep",
+					},
+				},
+			},
+		},
+		{
+			name:        "version > 1.30 preserves user-specified TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.31.0"),
+			inputValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"TLS12_ENABLED": "true",
+						"OTHER_VAR":     "keep",
+					},
+				},
+			},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{
+						"TLS12_ENABLED": "true",
+						"OTHER_VAR":     "keep",
+					},
+				},
+			},
+		},
+		{
+			name:        "version > 1.30 does not set TLS12_ENABLED even with FIPS",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.31.0"),
+			inputValues: &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{},
+				},
+			},
+		},
+		{
+			name:        "version 1.31-alpha does not set TLS12_ENABLED",
+			fipsEnabled: true,
+			version:     semver.MustParse("1.31.0-alpha.0"),
+			inputValues: &v1.ZTunnelValues{},
+			expectValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Env: map[string]string{},
+				},
+			},
 		},
 	}
 
@@ -204,7 +314,7 @@ func TestApplyZTunnelFipsValues(t *testing.T) {
 			originalFipsEnabled := FipsEnabled
 			t.Cleanup(func() { FipsEnabled = originalFipsEnabled })
 			FipsEnabled = tt.fipsEnabled
-			ApplyZTunnelFipsValues(tt.inputValues)
+			ApplyZTunnelFipsValues(tt.inputValues, tt.version)
 
 			if diff := cmp.Diff(tt.expectValues, tt.inputValues); diff != "" {
 				t.Errorf("TLS12_ENABLED env wasn't applied properly; diff (-expected, +actual):\n%v", diff)

--- a/pkg/istiovalues/tls.go
+++ b/pkg/istiovalues/tls.go
@@ -25,7 +25,10 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-var istio1_29 = semver.MustParse("1.29.0")
+var (
+	istio1_29 = semver.MustParse("1.29.0")
+	istio1_30 = semver.MustParse("1.30.0")
+)
 
 // ApplyTLSConfig applies TLS configuration to the Istio values.
 // If TLS settings are already set, they are not overridden.

--- a/pkg/reconcile/ztunnel.go
+++ b/pkg/reconcile/ztunnel.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
@@ -87,7 +88,11 @@ func (r *ZTunnelReconciler) ComputeValues(version string, userValues *v1.ZTunnel
 	userValues = ApplyZTunnelImageDigests(resolvedVersion, userValues, config.Config)
 
 	// apply fips values
-	istiovalues.ApplyZTunnelFipsValues(userValues)
+	parsedVersion, err := semver.NewVersion(resolvedVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ZTunnel version %q: %w", version, err)
+	}
+	istiovalues.ApplyZTunnelFipsValues(userValues, parsedVersion)
 
 	var mergedHelmValues helm.Values
 	if len(baseValues) > 0 && baseValues[0] != nil {

--- a/pkg/revision/values.go
+++ b/pkg/revision/values.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/helm"
@@ -62,7 +63,11 @@ func ComputeValues(
 	istiovalues.ApplyTLSConfig(tlsConfig, version, values)
 
 	// apply FipsValues on top of merged values from profile
-	istiovalues.ApplyFipsValues(values)
+	parsedVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Istio version %q: %w", version, err)
+	}
+	istiovalues.ApplyFipsValues(values, parsedVersion)
 
 	// override values that are not configurable by the user
 	istiovalues.ApplyOverrides(activeRevisionName, namespace, values)

--- a/pkg/revision/values_test.go
+++ b/pkg/revision/values_test.go
@@ -35,8 +35,9 @@ import (
 //   - other (non-value) fields in the IstioRevision resource (e.g. the value global.istioNamespace is set from IstioRevision.spec.namespace)
 func TestComputeValues(t *testing.T) {
 	const (
-		namespace    = "istio-system"
-		version      = "my-version"
+		namespace = "istio-system"
+		// Needs to be valid semver
+		version      = "1.30.0"
 		revisionName = "my-revision"
 	)
 	resourceDir := t.TempDir()
@@ -95,8 +96,9 @@ spec:
 // TestFipsComputeValues tests that the pilot.env.COMPLIANCE_POLICY is set in values
 func TestFipsComputeValues(t *testing.T) {
 	const (
-		namespace    = "istio-system"
-		version      = "my-version"
+		namespace = "istio-system"
+		// Needs to be valid semver
+		version      = "1.30.0"
 		revisionName = "my-revision"
 	)
 	resourceDir := t.TempDir()

--- a/tests/integration/api/ztunnel_test.go
+++ b/tests/integration/api/ztunnel_test.go
@@ -202,7 +202,8 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
 	})
 
-	It("sets TLS12_ENABLED on the ztunnel DaemonSet when FipsEnabled is true", func() {
+	// TODO: Remove this test when Istio 1.28 goes out of support
+	It("sets TLS12_ENABLED on the ztunnel DaemonSet when FipsEnabled is true and version < 1.30", func() {
 		originalFipsEnabled := istiovalues.FipsEnabled
 		DeferCleanup(func() {
 			istiovalues.FipsEnabled = originalFipsEnabled
@@ -214,7 +215,7 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 				Name: ztunnelName,
 			},
 			Spec: v1.ZTunnelSpec{
-				Version:   istioversion.Default,
+				Version:   "v1.28-latest",
 				Namespace: fipsZTunnelNamespace,
 			},
 		}
@@ -230,6 +231,39 @@ var _ = Describe("ZTunnel FIPS", Label("ztunnel", "fips"), Ordered, func() {
 		Expect(ds).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
 			ContainElement(corev1.EnvVar{Name: "TLS12_ENABLED", Value: "true"})))),
 			"Expected TLS12_ENABLED to be set to true on ztunnel DaemonSet when FIPS is enabled")
+	})
+
+	It("does not set TLS12_ENABLED on ztunnel DaemonSet when version >= 1.30", func() {
+		originalFipsEnabled := istiovalues.FipsEnabled
+		DeferCleanup(func() {
+			istiovalues.FipsEnabled = originalFipsEnabled
+		})
+		istiovalues.FipsEnabled = true
+
+		ztunnel := &v1.ZTunnel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ztunnelName,
+			},
+			Spec: v1.ZTunnelSpec{
+				Version:   istioversion.Default,
+				Namespace: fipsZTunnelNamespace,
+				Values: &v1.ZTunnelValues{
+					ZTunnel: &v1.ZTunnelConfig{},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ztunnel)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(ctx, ztunnel)).To(Succeed())
+			Eventually(k8sClient.Get).WithArguments(ctx, fipsZTunnelKey, &v1.ZTunnel{}).Should(ReturnNotFoundError())
+		})
+
+		ds := &appsv1.DaemonSet{}
+		Eventually(k8sClient.Get).WithArguments(ctx, daemonsetKey, ds).Should(Succeed())
+
+		Expect(ds).To(HaveContainersThat(ContainElement(WithTransform(getEnvVars,
+			Not(ContainElement(corev1.EnvVar{Name: "TLS12_ENABLED", Value: "true"}))))),
+			"Expected TLS12_ENABLED to not be set on ztunnel DaemonSet when version >= 1.30")
 	})
 })
 


### PR DESCRIPTION


 <!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Cherry-pick of ac7acd1c4 that works with istio 1.30 instead of 1.31+. On OpenShift fips 140-3 is supported with ZTunnel on Istio 1.30.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

Related Issue/PR #

#### Additional information:
