### PR TITLE
Fix short name curl

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,18 +60,22 @@ func ReadBytes(data []byte) error {
 }
 
 func decodeProperties(p *properties.Properties) error {
+	return decodePropertiesInto(p, &Config)
+}
+
+func decodePropertiesInto(p *properties.Properties, cfg *OperatorConfig) error {
 	for _, key := range p.Keys() {
 		val, _ := p.Get(key)
 		_, _, _ = p.Set(key, strings.Trim(val, `"`))
 	}
-	if err := p.Decode(&Config); err != nil {
+	if err := p.Decode(cfg); err != nil {
 		return err
 	}
 	// replace "_" in versions with "." (e.g. v1_20_0 => v1.20.0)
-	newImageDigests := make(map[string]IstioImageConfig, len(Config.ImageDigests))
-	for k, v := range Config.ImageDigests {
-		newImageDigests[strings.Replace(k, "_", ".", -1)] = v
+	newImageDigests := make(map[string]IstioImageConfig, len(cfg.ImageDigests))
+	for k, v := range cfg.ImageDigests {
+		newImageDigests[strings.ReplaceAll(k, "_", ".")] = v
 	}
-	Config.ImageDigests = newImageDigests
+	cfg.ImageDigests = newImageDigests
 	return nil
 }

--- a/pkg/config/images.go
+++ b/pkg/config/images.go
@@ -1,0 +1,66 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/magiconair/properties"
+)
+
+const imageAnnotationPrefix = "images.v"
+
+// ParseImageDigestsFromAnnotations extracts operand image refs from CSV install
+// deployment annotations (keys prefixed with images.v).
+func ParseImageDigestsFromAnnotations(ann map[string]string) (map[string]IstioImageConfig, error) {
+	var lines []string
+	for k, v := range ann {
+		if !strings.HasPrefix(k, imageAnnotationPrefix) {
+			continue
+		}
+		if strings.Contains(v, "${") {
+			return nil, fmt.Errorf("unresolved placeholder in annotation %s: %s", k, v)
+		}
+		lines = append(lines, k+"="+v)
+	}
+	if len(lines) == 0 {
+		return map[string]IstioImageConfig{}, nil
+	}
+
+	p, err := properties.Load([]byte(strings.Join(lines, "\n")), properties.UTF8)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg OperatorConfig
+	if err := decodePropertiesInto(p, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.ImageDigests, nil
+}
+
+// MergeImageDigests overlays parsed image digests into the global operator config.
+func MergeImageDigests(digests map[string]IstioImageConfig) {
+	if len(digests) == 0 {
+		return
+	}
+	if Config.ImageDigests == nil {
+		Config.ImageDigests = make(map[string]IstioImageConfig, len(digests))
+	}
+	for k, v := range digests {
+		Config.ImageDigests[k] = v
+	}
+}

--- a/pkg/config/images_test.go
+++ b/pkg/config/images_test.go
@@ -1,0 +1,152 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseImageDigestsFromAnnotations(t *testing.T) {
+	rhIstiod := "registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:abc123"
+	rhProxy := "registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:def456"
+	rhCNI := "registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ghi789"
+	rhZtunnel := "registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:jkl012"
+
+	testCases := []struct {
+		name    string
+		ann     map[string]string
+		want    map[string]IstioImageConfig
+		wantErr bool
+	}{
+		{
+			name: "rh digest annotations",
+			ann: map[string]string{
+				"images.v1_30_1.istiod":  rhIstiod,
+				"images.v1_30_1.proxy":   rhProxy,
+				"images.v1_30_1.cni":     rhCNI,
+				"images.v1_30_1.ztunnel": rhZtunnel,
+			},
+			want: map[string]IstioImageConfig{
+				"v1.30.1": {
+					IstiodImage:  rhIstiod,
+					ProxyImage:   rhProxy,
+					CNIImage:     rhCNI,
+					ZTunnelImage: rhZtunnel,
+				},
+			},
+		},
+		{
+			name: "ignores unrelated annotations",
+			ann: map[string]string{
+				"foo":                    "bar",
+				"images.v1_30_1.istiod":  rhIstiod,
+				"images.v1_30_1.proxy":   rhProxy,
+				"images.v1_30_1.cni":     rhCNI,
+				"images.v1_30_1.ztunnel": rhZtunnel,
+			},
+			want: map[string]IstioImageConfig{
+				"v1.30.1": {
+					IstiodImage:  rhIstiod,
+					ProxyImage:   rhProxy,
+					CNIImage:     rhCNI,
+					ZTunnelImage: rhZtunnel,
+				},
+			},
+		},
+		{
+			name: "ignores must-gather",
+			ann: map[string]string{
+				"images.v1_30_1.istiod":       rhIstiod,
+				"images.v1_30_1.proxy":        rhProxy,
+				"images.v1_30_1.cni":          rhCNI,
+				"images.v1_30_1.ztunnel":      rhZtunnel,
+				"images.v1_30_1.must-gather":  "registry.example.com/must-gather:latest",
+			},
+			want: map[string]IstioImageConfig{
+				"v1.30.1": {
+					IstiodImage:  rhIstiod,
+					ProxyImage:   rhProxy,
+					CNIImage:     rhCNI,
+					ZTunnelImage: rhZtunnel,
+				},
+			},
+		},
+		{
+			name: "empty annotations",
+			ann:  map[string]string{},
+			want: map[string]IstioImageConfig{},
+		},
+		{
+			name: "no matching prefix",
+			ann: map[string]string{
+				"other.key": "value",
+			},
+			want: map[string]IstioImageConfig{},
+		},
+		{
+			name: "rejects unresolved placeholder",
+			ann: map[string]string{
+				"images.v1_30_1.istiod": "${ISTIO_PILOT_1_30}",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseImageDigestsFromAnnotations(tc.ann)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal("digests did not match expectation:\n", diff)
+			}
+		})
+	}
+}
+
+func TestMergeImageDigests(t *testing.T) {
+	orig := Config.ImageDigests
+	t.Cleanup(func() {
+		Config.ImageDigests = orig
+	})
+
+	Config.ImageDigests = map[string]IstioImageConfig{
+		"v1.29.0": testImages,
+	}
+
+	overlay := map[string]IstioImageConfig{
+		"v1.30.1": {
+			IstiodImage: "overlay-istiod",
+		},
+	}
+	MergeImageDigests(overlay)
+
+	want := map[string]IstioImageConfig{
+		"v1.29.0": testImages,
+		"v1.30.1": {IstiodImage: "overlay-istiod"},
+	}
+	if diff := cmp.Diff(want, Config.ImageDigests); diff != "" {
+		t.Fatal("merged config did not match expectation:\n", diff)
+	}
+}

--- a/tests/e2e/gatewaycontroller/gateway_controller_suite_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_suite_test.go
@@ -24,6 +24,7 @@ import (
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/operandimages"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
@@ -74,4 +75,9 @@ func setup() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k = kubectl.New()
+
+	Expect(operandimages.MergeFromCSV(k, operandimages.Options{
+		Namespace:      common.OperatorNamespace,
+		DeploymentName: env.Get("DEPLOYMENT_NAME", "sail-operator"),
+	})).To(Succeed())
 }

--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -192,7 +192,7 @@ spec:
     %s
   containers:
   - name: curl
-    image: curlimages/curl
+    image: quay.io/curl/curl:8.16.0
     command: ["sleep", "3600"]
     securityContext:
       allowPrivilegeEscalation: false

--- a/tests/e2e/gatewaycontroller/gateway_controller_test.go
+++ b/tests/e2e/gatewaycontroller/gateway_controller_test.go
@@ -165,6 +165,19 @@ spec:
 			Expect(k.ApplyString(gatewayYAML)).To(Succeed())
 			Success("Gateway created")
 
+			// Define the platform specific security context snippets
+			var securityContextFields string
+			if env.GetBool("OCP", true) {
+				// OpenShift handles UID allocation dynamically via SCC
+				securityContextFields = `seccompProfile:
+      type: RuntimeDefault`
+			} else {
+				// Kind/Vanilla K8s requires explicit non-root enforcement
+				securityContextFields = `runAsNonRoot: true
+    runAsUser: 100
+    seccompProfile:
+      type: RuntimeDefault`
+			}
 			// Deploy a curl client pod for traffic testing
 			curlPodYAML := fmt.Sprintf(`
 apiVersion: v1
@@ -175,10 +188,17 @@ metadata:
   labels:
     sidecar.istio.io/inject: "false"
 spec:
+  securityContext:
+    %s
   containers:
   - name: curl
     image: curlimages/curl
-    command: ["sleep", "3600"]`, gatewayNamespace)
+    command: ["sleep", "3600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL`, gatewayNamespace, securityContextFields)
 			Expect(k.ApplyString(curlPodYAML)).To(Succeed())
 		})
 

--- a/tests/e2e/library/library_suite_test.go
+++ b/tests/e2e/library/library_suite_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/istio-ecosystem/sail-operator/pkg/env"
 	k8sclient "github.com/istio-ecosystem/sail-operator/tests/e2e/util/client"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/common"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/operandimages"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/dynamic"
@@ -74,4 +76,9 @@ func setup() {
 	Expect(err).NotTo(HaveOccurred())
 
 	k = kubectl.New()
+
+	Expect(operandimages.MergeFromCSV(k, operandimages.Options{
+		Namespace:      common.OperatorNamespace,
+		DeploymentName: env.Get("DEPLOYMENT_NAME", "sail-operator"),
+	})).To(Succeed())
 }

--- a/tests/e2e/util/operandimages/operandimages.go
+++ b/tests/e2e/util/operandimages/operandimages.go
@@ -1,0 +1,242 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operandimages
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
+	"github.com/istio-ecosystem/sail-operator/pkg/env"
+	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/kubectl"
+	. "github.com/onsi/ginkgo/v2"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	csvKind              = "csv"
+	deploymentKind       = "deployment"
+	olmOwnerAnnotation   = "olm.owner"
+	csvSucceededPhase    = "Succeeded"
+)
+
+// Options configures CSV operand image discovery.
+type Options struct {
+	Namespace      string // default: env NAMESPACE or "sail-operator"
+	CSVName        string // default: env OPERATOR_CSV, else discover
+	DeploymentName string // default: env DEPLOYMENT_NAME; used to pick install deployment entry
+}
+
+type csvDocument struct {
+	Spec struct {
+		Install struct {
+			Spec struct {
+				Deployments []csvInstallDeployment `json:"deployments" yaml:"deployments"`
+			} `json:"spec" yaml:"spec"`
+		} `json:"install" yaml:"install"`
+	} `json:"spec" yaml:"spec"`
+}
+
+type csvInstallDeployment struct {
+	Name string `json:"name" yaml:"name"`
+	Spec struct {
+		Template struct {
+			Metadata struct {
+				Annotations map[string]string `json:"annotations" yaml:"annotations"`
+			} `json:"metadata" yaml:"metadata"`
+		} `json:"template" yaml:"template"`
+	} `json:"spec" yaml:"spec"`
+}
+
+type csvList struct {
+	Items []struct {
+		Metadata struct {
+			Name string `json:"name" yaml:"name"`
+		} `json:"metadata" yaml:"metadata"`
+		Status struct {
+			Phase string `json:"phase" yaml:"phase"`
+		} `json:"status" yaml:"status"`
+	} `json:"items" yaml:"items"`
+}
+
+type deploymentDocument struct {
+	Metadata struct {
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+}
+
+// MergeFromCSV reads operand image refs from the operator CSV install deployment
+// annotations and merges them into config.Config.ImageDigests.
+func MergeFromCSV(k kubectl.Kubectl, opts Options) error {
+	opts.applyDefaults()
+	explicitCSV := opts.CSVName != ""
+
+	csvName, err := resolveCSVName(k, opts)
+	if err != nil {
+		if explicitCSV {
+			return err
+		}
+		return nil
+	}
+	if csvName == "" {
+		return nil
+	}
+
+	annotations, err := fetchInstallDeploymentAnnotations(k, opts.Namespace, csvName, opts.DeploymentName)
+	if err != nil {
+		if explicitCSV {
+			return err
+		}
+		return nil
+	}
+
+	digests, err := config.ParseImageDigestsFromAnnotations(annotations)
+	if err != nil {
+		return err
+	}
+	if len(digests) == 0 {
+		return nil
+	}
+
+	config.MergeImageDigests(digests)
+	GinkgoWriter.Printf("merged %d operand image digest entries from CSV %s\n", len(digests), csvName)
+	return nil
+}
+
+func (o *Options) applyDefaults() {
+	if o.Namespace == "" {
+		o.Namespace = env.Get("NAMESPACE", "sail-operator")
+	}
+	if o.DeploymentName == "" {
+		o.DeploymentName = env.Get("DEPLOYMENT_NAME", "sail-operator")
+	}
+	if o.CSVName == "" {
+		o.CSVName = os.Getenv("OPERATOR_CSV")
+	}
+}
+
+func resolveCSVName(k kubectl.Kubectl, opts Options) (string, error) {
+	if opts.CSVName != "" {
+		return opts.CSVName, nil
+	}
+
+	fromOwner, err := csvFromOLMOwner(k, opts.Namespace, opts.DeploymentName)
+	if err != nil {
+		return "", err
+	}
+	if fromOwner != "" {
+		return fromOwner, nil
+	}
+
+	return highestSucceededCSV(k, opts.Namespace)
+}
+
+func csvFromOLMOwner(k kubectl.Kubectl, namespace, deploymentName string) (string, error) {
+	yamlDoc, err := k.WithNamespace(namespace).GetYAML(deploymentKind, deploymentName)
+	if err != nil {
+		if isNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("getting operator deployment %s/%s: %w", namespace, deploymentName, err)
+	}
+
+	var dep deploymentDocument
+	if err := yaml.Unmarshal([]byte(yamlDoc), &dep); err != nil {
+		return "", fmt.Errorf("parsing operator deployment %s/%s: %w", namespace, deploymentName, err)
+	}
+
+	return dep.Metadata.Annotations[olmOwnerAnnotation], nil
+}
+
+func highestSucceededCSV(k kubectl.Kubectl, namespace string) (string, error) {
+	output, err := k.WithNamespace(namespace).GetYAML("csv", "")
+	if err != nil {
+		if isNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("listing CSVs in namespace %s: %w", namespace, err)
+	}
+
+	var list csvList
+	if err := yaml.Unmarshal([]byte(output), &list); err != nil {
+		return "", fmt.Errorf("parsing CSV list in namespace %s: %w", namespace, err)
+	}
+
+	var (
+		bestName    string
+		bestVersion *semver.Version
+	)
+	for _, item := range list.Items {
+		if item.Status.Phase != csvSucceededPhase {
+			continue
+		}
+		version, err := csvSemver(item.Metadata.Name)
+		if err != nil {
+			continue
+		}
+		if bestVersion == nil || version.GreaterThan(bestVersion) {
+			bestVersion = version
+			bestName = item.Metadata.Name
+		}
+	}
+	return bestName, nil
+}
+
+func csvSemver(csvName string) (*semver.Version, error) {
+	idx := strings.Index(csvName, ".v")
+	if idx < 0 {
+		return nil, fmt.Errorf("CSV name %q has no version suffix", csvName)
+	}
+	return semver.NewVersion(csvName[idx+1:])
+}
+
+func fetchInstallDeploymentAnnotations(k kubectl.Kubectl, namespace, csvName, deploymentName string) (map[string]string, error) {
+	yamlDoc, err := k.WithNamespace(namespace).GetYAML(csvKind, csvName)
+	if err != nil {
+		return nil, fmt.Errorf("getting CSV %s/%s: %w", namespace, csvName, err)
+	}
+	annotations, err := parseInstallDeploymentAnnotations(yamlDoc, deploymentName)
+	if err != nil {
+		return nil, fmt.Errorf("CSV %s/%s: %w", namespace, csvName, err)
+	}
+	return annotations, nil
+}
+
+func isNotFound(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "NotFound") || strings.Contains(msg, "not found")
+}
+
+// parseInstallDeploymentAnnotations extracts install deployment template annotations from CSV YAML.
+func parseInstallDeploymentAnnotations(yamlDoc, deploymentName string) (map[string]string, error) {
+	var doc csvDocument
+	if err := yaml.Unmarshal([]byte(yamlDoc), &doc); err != nil {
+		return nil, err
+	}
+	for _, dep := range doc.Spec.Install.Spec.Deployments {
+		if dep.Name == deploymentName {
+			return dep.Spec.Template.Metadata.Annotations, nil
+		}
+	}
+	names := make([]string, 0, len(doc.Spec.Install.Spec.Deployments))
+	for _, dep := range doc.Spec.Install.Spec.Deployments {
+		names = append(names, dep.Name)
+	}
+	return nil, fmt.Errorf("install deployment %q not found; available: %s", deploymentName, strings.Join(names, ", "))
+}

--- a/tests/e2e/util/operandimages/operandimages_test.go
+++ b/tests/e2e/util/operandimages/operandimages_test.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operandimages
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+const sampleCSV = `
+spec:
+  install:
+    spec:
+      deployments:
+        - name: servicemesh-operator3
+          spec:
+            template:
+              metadata:
+                annotations:
+                  images.v1_30_1.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:abc
+                  images.v1_30_1.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:def
+                  images.v1_30_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ghi
+                  images.v1_30_1.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:jkl
+        - name: other-deployment
+          spec:
+            template:
+              metadata:
+                annotations: {}
+`
+
+func TestParseInstallDeploymentAnnotations(t *testing.T) {
+	ann, err := parseInstallDeploymentAnnotations(sampleCSV, "servicemesh-operator3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digests, err := config.ParseImageDigestsFromAnnotations(ann)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]config.IstioImageConfig{
+		"v1.30.1": {
+			IstiodImage:  "registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:abc",
+			ProxyImage:   "registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:def",
+			CNIImage:     "registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ghi",
+			ZTunnelImage: "registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:jkl",
+		},
+	}
+	if diff := cmp.Diff(want, digests); diff != "" {
+		t.Fatal("digests did not match expectation:\n", diff)
+	}
+}
+
+func TestParseInstallDeploymentAnnotationsMissingDeployment(t *testing.T) {
+	_, err := parseInstallDeploymentAnnotations(sampleCSV, "missing")
+	if err == nil {
+		t.Fatal("expected error for missing deployment")
+	}
+}
+
+func TestCSVSemver(t *testing.T) {
+	version, err := csvSemver("servicemeshoperator3.v3.4.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version.String() != "3.4.0" {
+		t.Fatalf("expected 3.4.0, got %s", version)
+	}
+}
+
+func TestHighestSucceededCSVFromYAML(t *testing.T) {
+	const csvListYAML = `
+items:
+  - metadata:
+      name: servicemeshoperator3.v3.3.0
+    status:
+      phase: Succeeded
+  - metadata:
+      name: servicemeshoperator3.v3.4.0
+    status:
+      phase: Succeeded
+  - metadata:
+      name: servicemeshoperator3.v3.2.0
+    status:
+      phase: Failed
+`
+	var list csvList
+	if err := yaml.Unmarshal([]byte(csvListYAML), &list); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		bestName    string
+		bestVersion = mustSemver(t, "0.0.0")
+	)
+	for _, item := range list.Items {
+		if item.Status.Phase != csvSucceededPhase {
+			continue
+		}
+		version, err := csvSemver(item.Metadata.Name)
+		if err != nil {
+			continue
+		}
+		if version.GreaterThan(bestVersion) {
+			bestVersion = version
+			bestName = item.Metadata.Name
+		}
+	}
+	if bestName != "servicemeshoperator3.v3.4.0" {
+		t.Fatalf("expected servicemeshoperator3.v3.4.0, got %q", bestName)
+	}
+}
+
+func mustSemver(t *testing.T, v string) *semver.Version {
+	t.Helper()
+	sv, err := semver.NewVersion(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sv
+}

--- a/tests/e2e/ztwim/ztwim_test.go
+++ b/tests/e2e/ztwim/ztwim_test.go
@@ -581,7 +581,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl:8.16.0
+        image: quay.io/curl/curl:8.16.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Backport one test fix regarding gateway test + do not use shortname images since it causes an issue on IBM clusters. 
PR for upstream/midstream:
- https://github.com/openshift-service-mesh/sail-operator/pull/956
- https://github.com/istio-ecosystem/sail-operator/pull/2053
- https://github.com/istio-ecosystem/sail-operator/pull/2123