### PR TITLE
Do not use hardcoded curl image as shortname

### DIFF
--- a/tests/e2e/ztwim/ztwim_test.go
+++ b/tests/e2e/ztwim/ztwim_test.go
@@ -581,7 +581,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl:8.16.0
+        image: quay.io/curl/curl:8.16.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
Do not use shortname images since it causes an issue on IBM clusters in mirroring