### PR TITLE
OCPBUGS-84518: Add terminationMessagePolicy to servicemeshoperator3 container

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -830,6 +830,7 @@ spec:
                         port: 8081
                       initialDelaySeconds: 5
                       periodSeconds: 10
+                    terminationMessagePolicy: FallbackToLogsOnError
                     resources:
                       limits:
                         cpu: 500m

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -100,6 +100,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
         resources:
           limits:
             cpu: {{ .Values.operator.resources.limits.cpu }}


### PR DESCRIPTION
#### What type of PR is this?

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Test
- [ ] Documentation Update

#### What this PR does / why we need it:
Hi! This is a PR to add a terminationMessagePolicy to the servicemeshoperator3 container.

#### Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/OCPBUGS-84518
