### PR TITLE
test(dualstack): restore tcp-echo connectivity check

### DIFF
--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -180,15 +180,15 @@ values:
 					})
 
 					It("can access the dual-stack service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, DualStackNamespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, DualStackNamespace)
 					})
 
 					It("can access the ipv4 only service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv4Namespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv4Namespace)
 					})
 
 					It("can access the ipv6 only service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv6Namespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv6Namespace)
 					})
 				})
 
@@ -253,4 +253,11 @@ func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
 
 func getEnvVars(container corev1.Container) []corev1.EnvVar {
 	return container.Env
+}
+
+func checkTCPEchoConnectivity(podName, namespace, echoStr string) {
+	command := fmt.Sprintf(`sh -c 'echo %s | nc tcp-echo.%s 9000'`, echoStr, echoStr)
+	response, err := k.WithNamespace(namespace).Exec(podName, "sleep", command)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
+	Expect(response).To(ContainSubstring(fmt.Sprintf("hello %s", echoStr)), fmt.Sprintf("Unexpected response from %s pod", podName))
 }


### PR DESCRIPTION
- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [X] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Fixes the dualstack e2e test that was failing with DNS resolution errors on IPv6/dualstack clusters.

The test deploys tcp-echo services but was incorrectly using common.CheckPodConnectivity() which expects httpbin services and uses HTTP/curl. This caused the error:

error: curl httpbin.dual-stack.svc.cluster.local:8000/get
command terminated with exit code 6 (Couldn't resolve host)

This PR restores the checkTCPEchoConnectivity() function that properly tests TCP connectivity to tcp-echo services using netcat.

#### Which issue(s) this PR fixes:

Fixes #

Related Issue/PR #

#### Additional information:

- The function uses netcat to connect to tcp-echo services on port 9000
- Tests connectivity for dual-stack, IPv4-only, and IPv6-only namespaces
- Aligns test implementation with actual deployed services
- Test file: https://github.com/openshift-service-mesh/sail-operator/blob/release-3.4.0/tests/e2e/dualstack/dualstack_test.go
- Broken by commit: fb57d1b4 (cert-manager e2e test integration)

**TEST FIX NO NEED TO REBUILD**

**TESTED IN DOWNSTREAM**