### PR TITLE
[cherry-pick release-3.4] test(dualstack): restore tcp-echo connectivity check (#966)

### DIFF
--- a/tests/e2e/dualstack/dualstack_test.go
+++ b/tests/e2e/dualstack/dualstack_test.go
@@ -180,15 +180,15 @@ values:
 					})
 
 					It("can access the dual-stack service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, DualStackNamespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, DualStackNamespace)
 					})
 
 					It("can access the ipv4 only service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv4Namespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv4Namespace)
 					})
 
 					It("can access the ipv6 only service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv6Namespace, k)
+						checkTCPEchoConnectivity(sleepPod.Items[0].Name, SleepNamespace, IPv6Namespace)
 					})
 				})
 
@@ -253,4 +253,11 @@ func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
 
 func getEnvVars(container corev1.Container) []corev1.EnvVar {
 	return container.Env
+}
+
+func checkTCPEchoConnectivity(podName, namespace, echoStr string) {
+	command := fmt.Sprintf(`sh -c 'echo %s | nc tcp-echo.%s 9000'`, echoStr, echoStr)
+	response, err := k.WithNamespace(namespace).Exec(podName, "sleep", command)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
+	Expect(response).To(ContainSubstring(fmt.Sprintf("hello %s", echoStr)), fmt.Sprintf("Unexpected response from %s pod", podName))
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #966 from `release-3.4.0` to `release-3.4`.

- Restores the local `checkTCPEchoConnectivity()` helper in the dualstack test, replacing the incorrect `common.CheckPodConnectivity()` calls introduced by #869
- `common.CheckPodConnectivity()` curls httpbin, but the dualstack test deploys tcp-echo services (netcat on port 9000), causing DNS resolution failures
- This cherry-pick is required to unblock the automator sync PR #978, which brings in a new `containerName` parameter to `common.CheckPodConnectivity()` — without this fix, the dualstack callers have the wrong arity and fail lint

## Context

PR #869 ("Ossm 3.4 product changes") incorrectly replaced the local `checkTCPEchoConnectivity` with `common.CheckPodConnectivity` in the dualstack test. PR #966 fixed this on `release-3.4.0` but was never cherry-picked to `release-3.4`. The upstream branches (`main`, `release-1.30`) were never affected because they always used the local helper.
