### PR TITLE
fix(e2e): fix flaky cert-manager tests

### DIFF
--- a/tests/e2e/cert-manager/cert_manager_test.go
+++ b/tests/e2e/cert-manager/cert_manager_test.go
@@ -60,6 +60,14 @@ var _ = Describe("Cert-manager Installation", Label("smoke", "cert-manager", "sl
 
 		When("the Cert Manager Operator is deployed", func() {
 			BeforeAll(func() {
+				// Check that the cert-manager operator package is available in the catalog.
+				// If it is missing (e.g. nightly build without the operator), skip the test
+				// so CI surfaces it as "skipped" rather than a hard failure.
+				_, err := k.WithNamespace("openshift-marketplace").GetYAML("packagemanifests", "openshift-cert-manager-operator")
+				if err != nil {
+					Skip("openshift-cert-manager-operator package not found in operator catalog; skipping test suite")
+				}
+
 				operatorGroupYaml := `
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -315,8 +323,10 @@ spec:
 			})
 
 			It("waits for sample pods to be ready", func(ctx SpecContext) {
-				Eventually(common.CheckPodsReady).WithArguments(ctx, cl, common.SleepNamespace).Should(Succeed(), "Error checking status of sleep pod")
-				Eventually(common.CheckPodsReady).WithArguments(ctx, cl, common.HttpbinNamespace).Should(Succeed(), "Error checking status of httpbin pod")
+				Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("sleep", common.SleepNamespace), &appsv1.Deployment{}).
+					Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Sleep deployment is not Available")
+				Eventually(common.GetObject).WithArguments(ctx, cl, kube.Key("httpbin", common.HttpbinNamespace), &appsv1.Deployment{}).
+					Should(HaveConditionStatus(appsv1.DeploymentAvailable, metav1.ConditionTrue), "Httpbin deployment is not Available")
 				Success("Pods are ready")
 			})
 


### PR DESCRIPTION
## Summary

Partial cherry-pick of #982 to `release-3.3`.

The original PR fixed flaky ZTWIM and cert-manager tests. Only the cert-manager changes apply to this branch (the `ztwim/` directory and `cert_manager_ambient_test.go` do not exist on `release-3.3`).

Changes applied:
- Skip cert-manager tests when the `openshift-cert-manager-operator` package is not found in the catalog (e.g. nightly OCP builds); surfaces as "Skipped" instead of a hard failure
- Replace `CheckPodsReady` with `GetObject`/`HaveConditionStatus` for sample app pods to reduce flakiness

🤖 Generated with [Claude Code](https://claude.ai/claude-code)