### PR TITLE
manual sync upstream changes from PR #998 (manual)

### DIFF
--- a/pkg/helm/chartmanager.go
+++ b/pkg/helm/chartmanager.go
@@ -29,6 +29,7 @@ import (
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
 	"helm.sh/helm/v4/pkg/storage/driver"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
@@ -211,7 +212,17 @@ func (h *ChartManager) UninstallChart(ctx context.Context, releaseName, namespac
 
 	uninstallAction := action.NewUninstall(cfg)
 	uninstallAction.WaitStrategy = kube.HookOnlyStrategy
-	return uninstallAction.Run(releaseName)
+	resp, err := uninstallAction.Run(releaseName)
+	if err != nil {
+		var statusErr *apierrors.StatusError
+		if errors.As(err, &statusErr) && apierrors.IsNotFound(statusErr) {
+			// The release secret was deleted concurrently (e.g. namespace teardown racing
+			// with Helm's purge step). The release is gone regardless; treat as success.
+			return resp, nil
+		}
+		return nil, err
+	}
+	return resp, nil
 }
 
 func getRelease(cfg *action.Configuration, releaseName string) (release.Releaser, error) {

--- a/tests/e2e/library/library_reconcile_test.go
+++ b/tests/e2e/library/library_reconcile_test.go
@@ -18,7 +18,6 @@ package library
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -33,7 +32,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	"helm.sh/helm/v4/pkg/storage/driver"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -85,14 +83,7 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				// lib.Uninstall may race with Helm's internal purge step: after finding
-				// the release, the secret can be deleted concurrently before Helm purges
-				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
-				// deletes the namespace afterward regardless, so no state is left behind.
-				// Any other error is unexpected and must be reported.
-				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
-				}
+				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
 				lib.Stop()
 				Success("Cleaned up TLS test")
 			})
@@ -197,14 +188,7 @@ var _ = Describe("Library Reconciliation", Label("library", "reconciliation"), O
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				// lib.Uninstall may race with Helm's internal purge step: after finding
-				// the release, the secret can be deleted concurrently before Helm purges
-				// it, producing a spurious ErrReleaseNotFound. EnsureNamespaceWithCleanup
-				// deletes the namespace afterward regardless, so no state is left behind.
-				// Any other error is unexpected and must be reported.
-				if err := lib.Uninstall(ctx, namespace, revision); err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-					Expect(err).NotTo(HaveOccurred(), "unexpected error uninstalling Helm chart")
-				}
+				Expect(lib.Uninstall(ctx, namespace, revision)).To(Succeed())
 				lib.Stop()
 				Success("Cleaned up reconcile loop test")
 			})

--- a/tests/e2e/util/kubectl/kubectl.go
+++ b/tests/e2e/util/kubectl/kubectl.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/istio-ecosystem/sail-operator/pkg/test/project"
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/shell"
+	"github.com/onsi/gomega"
 )
 
 type Kubectl struct {
@@ -279,14 +280,34 @@ func (k Kubectl) GetSecret(secret string) (string, error) {
 	return output, nil
 }
 
-// Exec executes a command in the pod or specific container
+// Exec executes a command in the pod or specific container, retrying on transient WebSocket close
+// 1006 errors that occur on ARM64/Graviton2 when SPIRE ECDSA mTLS handshakes are slow.
 func (k Kubectl) Exec(pod, container, command string) (string, error) {
 	cmd := k.build(fmt.Sprintf(" exec %s %s -- %s", pod, containerFlag(container), command))
-	output, err := k.executeCommand(cmd)
-	if err != nil {
-		return "", err
+
+	var output string
+	var execErr error
+	// Noop fail handler: propagate the error to the caller rather than failing the test on timeout.
+	g := gomega.NewGomega(func(string, ...int) {})
+	g.Eventually(func() error {
+		output, execErr = k.executeCommand(cmd)
+		if isWebSocketCloseError(execErr) {
+			return execErr // keep retrying on transient WebSocket drops
+		}
+		return nil // success or non-retryable error — stop
+	}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+
+	return output, execErr
+}
+
+// isWebSocketCloseError returns true for WebSocket close 1006 (abnormal closure) errors.
+func isWebSocketCloseError(err error) bool {
+	if err == nil {
+		return false
 	}
-	return output, nil
+	msg := err.Error()
+	return strings.Contains(msg, "websocket: close 1006") ||
+		strings.Contains(msg, "abnormal closure")
 }
 
 // GetEvents returns the events of a namespace


### PR DESCRIPTION
## What this PR does / why we need it

Manual sync of the two upstream commits that PR #998 was attempting to bring in.
PR #998 had a lint failure because the bot branch conflicted with PR #999 (#999 removed `Rollout` and updated `ztwim_test.go`, while #998 still had the old state). Rather than waiting for the bot to rebase, this cherry-picks the upstream changes directly onto the current `main`.

**Commits included:**
- `test: handle concurrent secret deletion during Helm chart uninstall to fix Test Library flaky test (#2144)`
  - Moves the NotFound-during-uninstall guard from the test into `ChartManager.UninstallChart` and simplifies the library test
- `test: add kubectl utils func for ocp test related (#2146)`
  - Adds WebSocket close 1006 retry to `kubectl.Exec` (needed for ARM64/Graviton2 SPIRE ECDSA mTLS); removes the now-unused generic `Rollout` func (already resolved in #999)

Closes #998

## Related Issue/PR

Closes #998