### PR TITLE
[release-3.1.11] Add 3.0.14 & 3.1.11 placeholders

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_1}
-    createdAt: "2026-06-30T07:23:07Z"
+    createdAt: "2026-07-24T14:20:00Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -695,11 +695,11 @@ spec:
                   images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
                   images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
                   images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-                  images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:7276e863367c96403bc7808c19ac7e928e4165bcbad46aa0d4f038872a160f20
-                  images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:38e84a81d8a31c6f9db87ffdd8ab37fa55691b1d72990f9865f8827ac2d94897
-                  images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:7081c45738c2d043bbccd29fa98999d0cf6c2e9360d83460a1f3c3ba5025351b
-                  images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:20823aa6497b0704f3def7d8e9ba5f4bc0fa266c26100ebbac5662e0016ded2a
-                  images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:e353271b0ab60b72e2ce80c723f2423e4282a511e7c8ad1a4e8718b568aafd17
+                  images.v1_24_6.cni: ${ISTIO_CNI_1_24}
+                  images.v1_24_6.istiod: ${ISTIO_PILOT_1_24}
+                  images.v1_24_6.must-gather: ${OSSM_MUST_GATHER_3_0}
+                  images.v1_24_6.proxy: ${ISTIO_PROXY_1_24}
+                  images.v1_24_6.ztunnel: ${ISTIO_ZTUNNEL_1_24}
                   images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
                   images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
                   images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:366266f10e658c4cea86bddf6ee847e1908ea4dd780cb5f7fb0e466bac8995f1
@@ -720,11 +720,11 @@ spec:
                   images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
                   images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
                   images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
-                  images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:7830cdd82573d1e1e29ff52708c2a4999b92a8657a096fdf49e5b162c2fe5c8d
-                  images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d3fd7d783d5ff4c938a265e55bfb81e1a4f0ca26091da357948597d466d4b36c
-                  images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:991ea8bfe7aee5deb1287a48b62319fec03b73b35b9432c4123163b5ac855831
-                  images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:447a2c8947966ea6b7c5ff25d95714f45d7745309b6ab20a5569411bf6ad06a9
-                  images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:322965d5c6779c39336f9e5bab56ee22e40abca9e1e6af5483373f207b9a6f81
+                  images.v1_26_8.cni: ${ISTIO_CNI_1_26}
+                  images.v1_26_8.istiod: ${ISTIO_PILOT_1_26}
+                  images.v1_26_8.must-gather: ${OSSM_MUST_GATHER_3_1}
+                  images.v1_26_8.proxy: ${ISTIO_PROXY_1_26}
+                  images.v1_26_8.ztunnel: ${ISTIO_ZTUNNEL_1_26}
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: servicemeshoperator3

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -20,11 +20,11 @@ deployment:
     images.v1_24_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54cada48e5c9824f255f82daa2ef5bea236919e521d3ea49885f2883ced2b7bc
     images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
     # 1.24.6 will be replaced with Konflux built images
-    images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:7276e863367c96403bc7808c19ac7e928e4165bcbad46aa0d4f038872a160f20
-    images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:38e84a81d8a31c6f9db87ffdd8ab37fa55691b1d72990f9865f8827ac2d94897
-    images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:7081c45738c2d043bbccd29fa98999d0cf6c2e9360d83460a1f3c3ba5025351b
-    images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:20823aa6497b0704f3def7d8e9ba5f4bc0fa266c26100ebbac5662e0016ded2a
-    images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:e353271b0ab60b72e2ce80c723f2423e4282a511e7c8ad1a4e8718b568aafd17
+    images.v1_24_6.cni: ${ISTIO_CNI_1_24}
+    images.v1_24_6.istiod: ${ISTIO_PILOT_1_24}
+    images.v1_24_6.must-gather: ${OSSM_MUST_GATHER_3_0}
+    images.v1_24_6.proxy: ${ISTIO_PROXY_1_24}
+    images.v1_24_6.ztunnel: ${ISTIO_ZTUNNEL_1_24}
     # 1.26.2 images are hardcoded to versions released with 3.1.0
     images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
     images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
@@ -50,11 +50,11 @@ deployment:
     images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
     images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
     # 1.26.8 will be replaced with Konflux built images
-    images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:7830cdd82573d1e1e29ff52708c2a4999b92a8657a096fdf49e5b162c2fe5c8d
-    images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d3fd7d783d5ff4c938a265e55bfb81e1a4f0ca26091da357948597d466d4b36c
-    images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:991ea8bfe7aee5deb1287a48b62319fec03b73b35b9432c4123163b5ac855831
-    images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:447a2c8947966ea6b7c5ff25d95714f45d7745309b6ab20a5569411bf6ad06a9
-    images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:322965d5c6779c39336f9e5bab56ee22e40abca9e1e6af5483373f207b9a6f81
+    images.v1_26_8.cni: ${ISTIO_CNI_1_26}
+    images.v1_26_8.istiod: ${ISTIO_PILOT_1_26}
+    images.v1_26_8.must-gather: ${OSSM_MUST_GATHER_3_1}
+    images.v1_26_8.proxy: ${ISTIO_PROXY_1_26}
+    images.v1_26_8.ztunnel: ${ISTIO_ZTUNNEL_1_26}
 service:
   port: 8443
 serviceAccountName: servicemesh-operator3


### PR DESCRIPTION
SSIA

Same as #1024, targeted at `release-3.1.11`. Pattern from #848 / #894.


Made with [Cursor](https://cursor.com)