### PR TITLE
[release-3.4.1] Add 3.4.1, 3.3.6 and 3.2.8 placeholders

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_4}
-    createdAt: "2026-07-22T13:05:06Z"
+    createdAt: "2026-07-24T14:31:25Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -805,11 +805,11 @@ spec:
                   images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:c5374b333fbb37fa6d27c5b83524f2233a546ae4ecc89b1304a9557c8ce6a518
                   images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:234d58ad8033644a72f769ace359a5232c52a2532e851bd374334b3c4cf1d4d8
                   images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cb6adbadc22ca80888f06094c82a402a43526d8a3081e47e6332bcf5355729db
-                  images.v1_27_9.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:d31cdf38fdc469d55602b35ab12d25a20d1bd09f983f8a24af100e87825035dd
-                  images.v1_27_9.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:ec18f6e4f40610d872c9b0c9b6fa1b5701107609d86da8dc0e4488dea2b7273f
-                  images.v1_27_9.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:854220bd5edb3cfdfaea5df878a539de09e9c34c4ba8f4ed2465cf0085dc09c7
-                  images.v1_27_9.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ff4c42d8f13bebf89b2294dd9c5abaf5bbd751ced8b89cb882f89c070e17aef2
-                  images.v1_27_9.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:3c8a4ca43654cd3172bd18bc5b7442c14ace9849a6778d91851530bf6e605d02
+                  images.v1_27_9.cni: ${ISTIO_CNI_1_27}
+                  images.v1_27_9.istiod: ${ISTIO_PILOT_1_27}
+                  images.v1_27_9.must-gather: ${OSSM_MUST_GATHER_3_2}
+                  images.v1_27_9.proxy: ${ISTIO_PROXY_1_27}
+                  images.v1_27_9.ztunnel: ${ISTIO_ZTUNNEL_1_27}
                   images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
                   images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
                   images.v1_28_4.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d57d23fc8ec4053a3d819ffb87532d6aec6b5874fdf22e22afdd7f0f0712df52

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -23,11 +23,11 @@ deployment:
     images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:234d58ad8033644a72f769ace359a5232c52a2532e851bd374334b3c4cf1d4d8
     images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cb6adbadc22ca80888f06094c82a402a43526d8a3081e47e6332bcf5355729db
     # 1.27.9 images after 3.2.7 GA
-    images.v1_27_9.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:d31cdf38fdc469d55602b35ab12d25a20d1bd09f983f8a24af100e87825035dd
-    images.v1_27_9.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:ec18f6e4f40610d872c9b0c9b6fa1b5701107609d86da8dc0e4488dea2b7273f
-    images.v1_27_9.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:854220bd5edb3cfdfaea5df878a539de09e9c34c4ba8f4ed2465cf0085dc09c7
-    images.v1_27_9.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ff4c42d8f13bebf89b2294dd9c5abaf5bbd751ced8b89cb882f89c070e17aef2
-    images.v1_27_9.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:3c8a4ca43654cd3172bd18bc5b7442c14ace9849a6778d91851530bf6e605d02
+    images.v1_27_9.cni: ${ISTIO_CNI_1_27}
+    images.v1_27_9.istiod: ${ISTIO_PILOT_1_27}
+    images.v1_27_9.must-gather: ${OSSM_MUST_GATHER_3_2}
+    images.v1_27_9.proxy: ${ISTIO_PROXY_1_27}
+    images.v1_27_9.ztunnel: ${ISTIO_ZTUNNEL_1_27}
     # 1.28.4 images after 3.3.0 GA
     images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
     images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa


### PR DESCRIPTION
## Summary
- Replace pinned `v1_27_9` (3.2.8) image digests with build-time env var placeholders (`ISTIO_*_1_27` / `OSSM_MUST_GATHER_3_2`)
- `v1_30_3` (3.4.1) and `v1_28_10` (3.3.6) already had placeholders
- Update `createdAt`

Same as #1028, targeted at `release-3.4.1`. Pattern from #1020.

## Test plan
- [ ] Verify CSV and `ossm/values.yaml` use placeholders for `images.v1_27_9.*`, `images.v1_28_10.*`, and `images.v1_30_3.*`


Made with [Cursor](https://cursor.com)