### PR TITLE
Fix flaky cert-manager test: move Skip to outer BeforeAll

### DIFF
--- a/tests/e2e/cert-manager/cert_manager_test.go
+++ b/tests/e2e/cert-manager/cert_manager_test.go
@@ -50,6 +50,14 @@ var _ = Describe("Cert-manager Installation", Label("smoke", "cert-manager", "sl
 	Describe(fmt.Sprintf("Istio version: %s", latestVersion.Name), func() {
 		clr := cleaner.New(cl)
 		BeforeAll(func(ctx SpecContext) {
+			// Check that the cert-manager operator package is available in the catalog.
+			// If it is missing (e.g. nightly build without the operator), skip the entire
+			// suite so CI surfaces it as "skipped" rather than a hard failure.
+			_, err := k.WithNamespace("openshift-marketplace").GetYAML("packagemanifests", "openshift-cert-manager-operator")
+			if err != nil {
+				Skip("openshift-cert-manager-operator package not found in operator catalog; skipping test suite")
+			}
+
 			clr.Record(ctx)
 			Expect(k.CreateNamespace(controlPlaneNamespace)).To(Succeed(), "Istio namespace failed to be created")
 			Expect(k.CreateNamespace(istioCniNamespace)).To(Succeed(), "IstioCNI namespace failed to be created")
@@ -60,14 +68,6 @@ var _ = Describe("Cert-manager Installation", Label("smoke", "cert-manager", "sl
 
 		When("the Cert Manager Operator is deployed", func() {
 			BeforeAll(func() {
-				// Check that the cert-manager operator package is available in the catalog.
-				// If it is missing (e.g. nightly build without the operator), skip the test
-				// so CI surfaces it as "skipped" rather than a hard failure.
-				_, err := k.WithNamespace("openshift-marketplace").GetYAML("packagemanifests", "openshift-cert-manager-operator")
-				if err != nil {
-					Skip("openshift-cert-manager-operator package not found in operator catalog; skipping test suite")
-				}
-
 				operatorGroupYaml := `
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
## Summary

- In an `Ordered` Ginkgo container, `Skip` inside an inner `When`'s `BeforeAll` only skips that container's specs — sibling `When` blocks still run.
- The second `When("root CA issuer...")` `BeforeAll` was patching the `openshift-cert-manager-operator` subscription that was never created (because the first `When`'s `BeforeAll` called `Skip`), resulting in a `NotFound` failure instead of a clean skip.
- Fix: move the package-availability check to the outer `BeforeAll` so the entire suite skips when the operator is absent from the catalog.


🤖 Generated with [Claude Code](https://claude.com/claude-code)