### PR TITLE
[release-3.3.6] Fix default tag's VWC Service reference + fix Webhook filter

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -77,6 +77,7 @@ func NewReconciler(reconcilerCfg config.ReconcilerConfig, client client.Client, 
 // +kubebuilder:rbac:groups=sailoperator.io,resources=istiorevisiontags/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=sailoperator.io,resources=istiorevisiontags/finalizers,verbs=update
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs="*"
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs="*"
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //
@@ -203,7 +204,10 @@ func (r *Reconciler) installHelmCharts(ctx context.Context, tag *v1.IstioRevisio
 	if err != nil {
 		return fmt.Errorf("failed to install/update Helm chart %q: %w", revisionTagsChartName, err)
 	}
-	if tag.Name == v1.DefaultRevision {
+	if tag.Name == v1.DefaultRevisionTag {
+		if err := values.Set("defaultRevision", rev.Name); err != nil {
+			return err
+		}
 		_, err := r.ChartManager.UpgradeOrInstallChart(ctx, r.Config.ResourceFS, r.getChartPath(rev, constants.BaseChartName),
 			values, r.Config.OperatorNamespace, getReleaseName(tag, constants.BaseChartName), &ownerReference)
 		if err != nil {
@@ -226,8 +230,7 @@ func (r *Reconciler) uninstallHelmCharts(ctx context.Context, tag *v1.IstioRevis
 		return fmt.Errorf("failed to uninstall Helm chart %q: %w", revisionTagsChartName, err)
 	}
 	if tag.Name == v1.DefaultRevisionTag {
-		_, err := r.ChartManager.UninstallChart(ctx, getReleaseName(tag, constants.BaseChartName), r.Config.OperatorNamespace)
-		if err != nil {
+		if _, err := r.ChartManager.UninstallChart(ctx, getReleaseName(tag, constants.BaseChartName), r.Config.OperatorNamespace); err != nil {
 			return fmt.Errorf("failed to uninstall Helm chart %q: %w", constants.BaseChartName, err)
 		}
 	}
@@ -279,6 +282,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
 		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -281,8 +281,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// cluster-scoped resources
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
-		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
-		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(webhookConfigPredicate())).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(webhookConfigPredicate())).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 
@@ -470,6 +472,42 @@ func (r *Reconciler) mapOperatorResourceToReconcileRequest(ctx context.Context, 
 		}
 	}
 	return requests
+}
+
+func webhookConfigPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			// Istiod updates the caBundle and failurePolicy fields in its webhook configs.
+			// We must ignore changes to these fields to prevent an endless update loop.
+			// We must use deep copies to avoid mutating the shared informer cache.
+			oldCopy := e.ObjectOld.DeepCopyObject().(client.Object)
+			newCopy := e.ObjectNew.DeepCopyObject().(client.Object)
+			clearIgnoredFields(oldCopy)
+			clearIgnoredFields(newCopy)
+			return !reflect.DeepEqual(newCopy, oldCopy)
+		},
+	}
+}
+
+func clearIgnoredFields(obj client.Object) {
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetManagedFields(nil)
+	switch webhookConfig := obj.(type) {
+	case *admissionv1.ValidatingWebhookConfiguration:
+		for i := range len(webhookConfig.Webhooks) {
+			webhookConfig.Webhooks[i].FailurePolicy = nil
+			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	case *admissionv1.MutatingWebhookConfiguration:
+		for i := range len(webhookConfig.Webhooks) {
+			webhookConfig.Webhooks[i].ClientConfig.CABundle = nil
+		}
+	}
 }
 
 // ignoreStatusChange returns a predicate that ignores watch events where only the resource status changes; if

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/istio-ecosystem/sail-operator/tests/e2e/util/gomega"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,6 +109,51 @@ spec:
 						Should(HaveField("Status.IstioRevision", ContainSubstring(revisionName)),
 							"IstioRevisionTag version does not match the IstioRevision name of the base version")
 					Success("IstioRevisionTag version matches the Istio version")
+				})
+
+				It("istiod-default-validator VWC has failurePolicy Fail", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						vwc := &admissionv1.ValidatingWebhookConfiguration{}
+						g.Expect(cl.Get(ctx, kube.Key("istiod-default-validator"), vwc)).To(Succeed())
+						g.Expect(vwc.Webhooks).NotTo(BeEmpty())
+						g.Expect(vwc.Webhooks[0].FailurePolicy).To(HaveValue(Equal(admissionv1.Fail)),
+							"failurePolicy must be Fail before testing validation; Ignore would make subsequent tests meaningless")
+					}).Should(Succeed())
+					Success("VWC failurePolicy is Fail — webhook is active")
+				})
+
+				It("istiod-default-validator VWC accepts valid Istio resources", func() {
+					peerAuthYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: vwc-test
+  namespace: %s
+spec:
+  mtls:
+    mode: STRICT`, controlPlaneNamespace)
+					Expect(k.CreateFromString(peerAuthYAML)).To(Succeed(),
+						"VWC should allow creating valid Istio resources; if this fails, the istiod-default-validator may point to the wrong service")
+					DeferCleanup(func() {
+						if err := k.Delete("peerauthentication", "vwc-test"); err != nil {
+							Log(fmt.Sprintf("Failed to delete PeerAuthentication: %s", err))
+						}
+					})
+					Success("Valid Istio resource accepted by the default-validator VWC")
+				})
+
+				It("istiod-default-validator VWC rejects invalid Istio resources", func() {
+					invalidDRYAML := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: vwc-test-invalid
+  namespace: %s
+spec:
+  host: ""`, controlPlaneNamespace)
+					Expect(k.CreateFromString(invalidDRYAML)).ToNot(Succeed(),
+						"VWC should reject invalid Istio resources; if this passes, the webhook may not be validating")
+					Success("Invalid Istio resource correctly rejected by the default-validator VWC")
 				})
 			})
 

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -155,6 +155,15 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
 						webhook := &admissionv1.ValidatingWebhookConfiguration{}
 						Eventually(k8sClient.Get).WithArguments(ctx, webhookKey, webhook).Should(Succeed())
+
+						revisionName := getRevisionName(istio, istioversion.Base)
+						expectedServiceName := "istiod-" + revisionName
+						Expect(webhook.Webhooks).To(HaveLen(1))
+						Expect(webhook.Webhooks[0].ClientConfig.Service).ToNot(BeNil())
+						Expect(webhook.Webhooks[0].ClientConfig.Service.Name).To(Equal(expectedServiceName),
+							"VWC should point to the istiod service for the referenced revision")
+						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
+							"VWC should point to the correct namespace for the referenced revision")
 					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -165,6 +165,48 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
 							"VWC should point to the correct namespace for the referenced revision")
 					})
+
+					It("skips reconcile when only caBundle and failurePolicy are updated on ValidatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhook := &admissionv1.ValidatingWebhookConfiguration{}
+						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+						Expect(k8sClient.Get(ctx, webhookKey, webhook)).To(Succeed())
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle and failurePolicy on ValidatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+								webhook.Webhooks[i].FailurePolicy = ptr.Of(admissionv1.Fail)
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
+
+					It("skips reconcile when only caBundle is updated on MutatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhookList := &admissionv1.MutatingWebhookConfigurationList{}
+						Expect(k8sClient.List(ctx, webhookList)).To(Succeed())
+						var webhook *admissionv1.MutatingWebhookConfiguration
+						for i := range webhookList.Items {
+							for _, ref := range webhookList.Items[i].OwnerReferences {
+								if ref.Kind == v1.IstioRevisionTagKind {
+									webhook = &webhookList.Items[i]
+									break
+								}
+							}
+						}
+						Expect(webhook).ToNot(BeNil(), "expected to find a MutatingWebhookConfiguration owned by the IstioRevisionTag")
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle on MutatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {
 					BeforeAll(func() {

--- a/tests/integration/api/utils.go
+++ b/tests/integration/api/utils.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	istioRevisionController = "istiorevision"
-	istioCNIController      = "istiocni"
+	istioRevisionController    = "istiorevision"
+	istioRevisionTagController = "istiorevisiontag"
+	istioCNIController         = "istiocni"
 )
 
 func getReconcileCount(g Gomega, controllerName string) float64 {


### PR DESCRIPTION
Backported commits from [release-3.3](https://github.com/openshift-service-mesh/sail-operator/commits/release-3.3/) into code-frozen release-3.3.6