### PR TITLE
[release-3.4.1] Fix default tag's VWC Service reference + fix Webhook filter

### DIFF
--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -76,6 +76,7 @@ func NewReconciler(reconcilerCfg config.ReconcilerConfig, client client.Client, 
 // +kubebuilder:rbac:groups=sailoperator.io,resources=istiorevisiontags/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=sailoperator.io,resources=istiorevisiontags/finalizers,verbs=update
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs="*"
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs="*"
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //
@@ -176,7 +177,10 @@ func (r *Reconciler) installHelmCharts(ctx context.Context, tag *v1.IstioRevisio
 	if err != nil {
 		return fmt.Errorf("failed to install/update Helm chart %q: %w", revisionTagsChartName, err)
 	}
-	if tag.Name == v1.DefaultRevision {
+	if tag.Name == v1.DefaultRevisionTag {
+		if err := values.Set("defaultRevision", rev.Name); err != nil {
+			return err
+		}
 		_, err := r.ChartManager.UpgradeOrInstallChart(ctx, r.Config.ResourceFS, r.getChartPath(rev, constants.BaseChartName),
 			values, r.Config.OperatorNamespace, getReleaseName(tag, constants.BaseChartName), &ownerReference)
 		if err != nil {
@@ -199,8 +203,7 @@ func (r *Reconciler) uninstallHelmCharts(ctx context.Context, tag *v1.IstioRevis
 		return fmt.Errorf("failed to uninstall Helm chart %q: %w", revisionTagsChartName, err)
 	}
 	if tag.Name == v1.DefaultRevisionTag {
-		_, err := r.ChartManager.UninstallChart(ctx, getReleaseName(tag, constants.BaseChartName), r.Config.OperatorNamespace)
-		if err != nil {
+		if _, err := r.ChartManager.UninstallChart(ctx, getReleaseName(tag, constants.BaseChartName), r.Config.OperatorNamespace); err != nil {
 			return fmt.Errorf("failed to uninstall Helm chart %q: %w", constants.BaseChartName, err)
 		}
 	}
@@ -252,6 +255,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
 		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/controllers/istiorevisiontag/istiorevisiontag_controller.go
+++ b/controllers/istiorevisiontag/istiorevisiontag_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/reconciler"
 	"github.com/istio-ecosystem/sail-operator/pkg/revision"
 	"github.com/istio-ecosystem/sail-operator/pkg/validation"
+	"github.com/istio-ecosystem/sail-operator/pkg/watches"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -254,8 +255,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// cluster-scoped resources
 		Watches(&v1.Istio{}, operatorResourcesHandler).
 		Watches(&v1.IstioRevision{}, operatorResourcesHandler).
-		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler).
-		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler).
+		Watches(&admissionv1.MutatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(watches.AsPredicate(watches.WebhookFilter()))).
+		Watches(&admissionv1.ValidatingWebhookConfiguration{}, ownedResourceHandler,
+			builder.WithPredicates(watches.AsPredicate(watches.WebhookFilter()))).
 		Complete(reconciler.NewStandardReconcilerWithFinalizer[*v1.IstioRevisionTag](r.Client, r.Reconcile, r.Finalize, constants.FinalizerName))
 }
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/istio-ecosystem/sail-operator/tests/e2e/util/update"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,51 @@ spec:
 						Should(HaveField("Status.IstioRevision", ContainSubstring(revisionName)),
 							"IstioRevisionTag version does not match the IstioRevision name of the base version")
 					Success("IstioRevisionTag version matches the Istio version")
+				})
+
+				It("istiod-default-validator VWC has failurePolicy Fail", func(ctx SpecContext) {
+					Eventually(func(g Gomega) {
+						vwc := &admissionv1.ValidatingWebhookConfiguration{}
+						g.Expect(cl.Get(ctx, kube.Key("istiod-default-validator"), vwc)).To(Succeed())
+						g.Expect(vwc.Webhooks).NotTo(BeEmpty())
+						g.Expect(vwc.Webhooks[0].FailurePolicy).To(HaveValue(Equal(admissionv1.Fail)),
+							"failurePolicy must be Fail before testing validation; Ignore would make subsequent tests meaningless")
+					}).Should(Succeed())
+					Success("VWC failurePolicy is Fail — webhook is active")
+				})
+
+				It("istiod-default-validator VWC accepts valid Istio resources", func() {
+					peerAuthYAML := fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: vwc-test
+  namespace: %s
+spec:
+  mtls:
+    mode: STRICT`, controlPlaneNamespace)
+					Expect(k.CreateFromString(peerAuthYAML)).To(Succeed(),
+						"VWC should allow creating valid Istio resources; if this fails, the istiod-default-validator may point to the wrong service")
+					DeferCleanup(func() {
+						if err := k.Delete("peerauthentication", "vwc-test"); err != nil {
+							Log(fmt.Sprintf("Failed to delete PeerAuthentication: %s", err))
+						}
+					})
+					Success("Valid Istio resource accepted by the default-validator VWC")
+				})
+
+				It("istiod-default-validator VWC rejects invalid Istio resources", func() {
+					invalidDRYAML := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: vwc-test-invalid
+  namespace: %s
+spec:
+  host: ""`, controlPlaneNamespace)
+					Expect(k.CreateFromString(invalidDRYAML)).ToNot(Succeed(),
+						"VWC should reject invalid Istio resources; if this passes, the webhook may not be validating")
+					Success("Invalid Istio resource correctly rejected by the default-validator VWC")
 				})
 			})
 

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -155,6 +155,15 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
 						webhook := &admissionv1.ValidatingWebhookConfiguration{}
 						Eventually(k8sClient.Get).WithArguments(ctx, webhookKey, webhook).Should(Succeed())
+
+						revisionName := getRevisionName(istio, istioversion.Base)
+						expectedServiceName := "istiod-" + revisionName
+						Expect(webhook.Webhooks).To(HaveLen(1))
+						Expect(webhook.Webhooks[0].ClientConfig.Service).ToNot(BeNil())
+						Expect(webhook.Webhooks[0].ClientConfig.Service.Name).To(Equal(expectedServiceName),
+							"VWC should point to the istiod service for the referenced revision")
+						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
+							"VWC should point to the correct namespace for the referenced revision")
 					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {

--- a/tests/integration/api/istiorevisiontag_test.go
+++ b/tests/integration/api/istiorevisiontag_test.go
@@ -165,6 +165,48 @@ var _ = Describe("IstioRevisionTag resource", Label("istiorevisiontag"), Ordered
 						Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(istio.Spec.Namespace),
 							"VWC should point to the correct namespace for the referenced revision")
 					})
+
+					It("skips reconcile when only caBundle and failurePolicy are updated on ValidatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhook := &admissionv1.ValidatingWebhookConfiguration{}
+						webhookKey := client.ObjectKey{Name: "istiod-default-validator"}
+						Expect(k8sClient.Get(ctx, webhookKey, webhook)).To(Succeed())
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle and failurePolicy on ValidatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+								webhook.Webhooks[i].FailurePolicy = ptr.Of(admissionv1.Fail)
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
+
+					It("skips reconcile when only caBundle is updated on MutatingWebhookConfiguration", func() {
+						time.Sleep(5 * time.Second)
+
+						webhookList := &admissionv1.MutatingWebhookConfigurationList{}
+						Expect(k8sClient.List(ctx, webhookList)).To(Succeed())
+						var webhook *admissionv1.MutatingWebhookConfiguration
+						for i := range webhookList.Items {
+							for _, ref := range webhookList.Items[i].OwnerReferences {
+								if ref.Kind == v1.IstioRevisionTagKind {
+									webhook = &webhookList.Items[i]
+									break
+								}
+							}
+						}
+						Expect(webhook).ToNot(BeNil(), "expected to find a MutatingWebhookConfiguration owned by the IstioRevisionTag")
+
+						expectNoReconciliation(istioRevisionTagController, func() {
+							By("updating caBundle on MutatingWebhookConfiguration")
+							for i := range webhook.Webhooks {
+								webhook.Webhooks[i].ClientConfig.CABundle = []byte("new-ca-bundle-data")
+							}
+							Expect(k8sClient.Update(ctx, webhook)).To(Succeed())
+						})
+					})
 				})
 				When("workload ns is labeled with istio-injection label", func() {
 					BeforeAll(func() {

--- a/tests/integration/api/utils.go
+++ b/tests/integration/api/utils.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	istioRevisionController = "istiorevision"
-	istioCNIController      = "istiocni"
+	istioRevisionController    = "istiorevision"
+	istioRevisionTagController = "istiorevisiontag"
+	istioCNIController         = "istiocni"
 )
 
 func getReconcileCount(g Gomega, controllerName string) float64 {


### PR DESCRIPTION
Backported commits from [release-3.4](https://github.com/openshift-service-mesh/sail-operator/commits/release-3.4/) into code-frozen release-3.4.1