### PR TITLE
test: fix e2e test failures on cert-manager, ZTWIM, and control plane updates

### DIFF
--- a/tests/e2e/cert-manager/cert_manager_ambient_test.go
+++ b/tests/e2e/cert-manager/cert_manager_ambient_test.go
@@ -226,10 +226,10 @@ spec:
 
 			It("has IstioCSR pods running", func(ctx SpecContext) {
 				Eventually(common.CheckPodsReady).
-					WithArguments(ctx, cl, certManagerNamespace).
-					Should(Succeed(), fmt.Sprintf("Some pods in namespace %q are not ready", certManagerNamespace))
+					WithArguments(ctx, cl, istioCSRNamespace).
+					Should(Succeed(), fmt.Sprintf("Some pods in namespace %q are not ready", istioCSRNamespace))
 
-				Success("All cert-manager pods are ready")
+				Success("All IstioCSR pods are ready")
 			})
 		})
 

--- a/tests/e2e/cert-manager/cert_manager_test.go
+++ b/tests/e2e/cert-manager/cert_manager_test.go
@@ -231,10 +231,10 @@ spec:
 
 			It("has IstioCSR pods running", func(ctx SpecContext) {
 				Eventually(common.CheckPodsReady).
-					WithArguments(ctx, cl, certManagerNamespace).
-					Should(Succeed(), fmt.Sprintf("Some pods in namespace %q are not ready", certManagerNamespace))
+					WithArguments(ctx, cl, istioCSRNamespace).
+					Should(Succeed(), fmt.Sprintf("Some pods in namespace %q are not ready", istioCSRNamespace))
 
-				Success("All cert-manager pods are ready")
+				Success("All IstioCSR pods are ready")
 			})
 		})
 

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -139,7 +139,9 @@ metadata:
 spec:
   mtls:
     mode: STRICT`, controlPlaneNamespace)
-					Expect(k.CreateFromString(peerAuthYAML)).To(Succeed(),
+					Eventually(func() error {
+						return k.CreateFromString(peerAuthYAML)
+					}, 30*time.Second, 5*time.Second).Should(Succeed(),
 						"VWC should allow creating valid Istio resources; if this fails, the istiod-default-validator may point to the wrong service")
 					DeferCleanup(func() {
 						if err := k.Delete("peerauthentication", "vwc-test"); err != nil {

--- a/tests/e2e/ztwim/ztwim_test.go
+++ b/tests/e2e/ztwim/ztwim_test.go
@@ -36,6 +36,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var latestVersion = istioversion.GetLatestPatchVersions()[0]
@@ -48,7 +49,7 @@ type daemonSetStatus struct {
 }
 
 var _ = Describe("ZTWIM Installation", Label("smoke", "ztwim", "slow"), Ordered, func() {
-	SetDefaultEventuallyTimeout(180 * time.Second)
+	SetDefaultEventuallyTimeout(10 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	debugInfoLogged := false
 
@@ -80,7 +81,7 @@ metadata:
   namespace: %s
 spec:
   upgradeStrategy: Default`, ztwimOperatorName, ztwimNamespace)
-				Expect(k.WithNamespace(ztwimNamespace).CreateFromString(operatorGroupYaml)).To(Succeed(), "OperatorGroup creation failed")
+				Expect(k.WithNamespace(ztwimNamespace).ApplyString(operatorGroupYaml)).To(Succeed(), "OperatorGroup creation/apply failed")
 
 				// Apply Subscription YAML
 				subscriptionYaml := fmt.Sprintf(`
@@ -95,13 +96,27 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic`, ztwimOperatorName, ztwimNamespace, ztwimOperatorName)
-				Expect(k.WithNamespace(ztwimNamespace).CreateFromString(subscriptionYaml)).To(Succeed(), "Subscription creation failed")
+				Expect(k.WithNamespace(ztwimNamespace).ApplyString(subscriptionYaml)).To(Succeed(), "Subscription creation/apply failed")
 			})
 
 			It("should have subscription created successfully", func() {
 				output, err := k.WithNamespace(ztwimNamespace).GetYAML("subscription", ztwimOperatorName)
 				Expect(err).NotTo(HaveOccurred(), "error getting subscription YAML")
 				Expect(output).To(ContainSubstring(ztwimNamespace), "Subscription is not created")
+			})
+
+			It("waits for the operator deployment to be created by OLM", func(ctx SpecContext) {
+				Eventually(func() error {
+					deployments := &appsv1.DeploymentList{}
+					err := cl.List(ctx, deployments, client.InNamespace(ztwimNamespace))
+					if err != nil {
+						return err
+					}
+					if len(deployments.Items) == 0 {
+						return fmt.Errorf("no deployments found in namespace %s yet", ztwimNamespace)
+					}
+					return nil
+				}, 10*time.Minute, 5*time.Second).Should(Succeed(), "ZTWIM Operator Deployment never appeared")
 			})
 
 			It("verifies all ZTWIM pods are Ready", func(ctx SpecContext) {
@@ -113,22 +128,43 @@ spec:
 			})
 		})
 
-		When("ZTWIM Operator Patched", func() {
-			BeforeAll(func() {
+		When("ZTWIM Operands Deployed", func() {
+			BeforeAll(func(ctx SpecContext) {
+				By("Patching ZTWIM subscription with env vars")
+				envVars := []string{`{"name":"CREATE_ONLY_MODE","value":"true"}`}
+
+				proxyYAML, _ := k.GetYAML("proxy", "cluster")
+				if strings.Contains(proxyYAML, "httpProxy") {
+					By("Creating trusted CA bundle ConfigMap for proxy-enabled cluster")
+					caBundleCM := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca-bundle
+  namespace: %s
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+data: {}`, ztwimNamespace)
+					Expect(k.WithNamespace(ztwimNamespace).ApplyString(caBundleCM)).To(Succeed(), "Failed to create trusted CA bundle ConfigMap")
+					envVars = append(envVars, `{"name":"TRUSTED_CA_BUNDLE_CONFIGMAP","value":"trusted-ca-bundle"}`)
+				}
+
+				patchJSON := fmt.Sprintf(`{"spec":{"config":{"env":[%s]}}}`, strings.Join(envVars, ","))
 				Expect(
 					k.WithNamespace(ztwimNamespace).Patch(
 						"subscription",
 						ztwimOperatorName,
 						"merge",
-						`{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"true"}]}}}`,
+						patchJSON,
 					),
 				).To(Succeed(), "Error patching ZTWIM")
 				Success("ZTWIM subscription patched")
-			})
-		})
 
-		When("ZTWIM Operands Deployed", func() {
-			BeforeAll(func() {
+				By("Waiting for ZTWIM operator pods to be ready after subscription patch")
+				Eventually(common.CheckPodsReady).
+					WithArguments(ctx, cl, ztwimNamespace).
+					Should(Succeed(), fmt.Sprintf("ZTWIM operator pods not ready after subscription patch in namespace %q", ztwimNamespace))
+				Success("ZTWIM operator pods ready after patch")
 				if jwtIssuer == "" {
 					Eventually(func() error {
 						var err error
@@ -167,7 +203,7 @@ spec:
     organization: "Sky Computing Corporation"
     commonName: "SPIRE Server CA"
   persistence:
-    size: "5Gi"
+    size: "1Gi"
     accessMode: "ReadWriteOnce"
   datastore:
     databaseType: "sqlite3"
@@ -348,42 +384,12 @@ spec:
 				).To(Succeed(), "SpireOIDCDiscoveryProvider custom resource creation failed")
 			})
 
-			It("configures and restarts spire-spiffe-oidc-discovery-provider", func() {
+			It("waits for spire-spiffe-oidc-discovery-provider deployment to be available", func() {
 				By("Waiting for OIDC discovery provider deployment to be available")
 				Eventually(func() error {
 					_, err := k.WithNamespace(ztwimNamespace).RolloutStatus("deployment/spire-spiffe-oidc-discovery-provider")
 					return err
 				}, 300*time.Second, 5*time.Second).Should(Succeed(), "OIDC discovery provider deployment did not become available")
-
-				By("Patching OIDC discovery provider configmap")
-				bin := os.Getenv("COMMAND")
-				if bin == "" {
-					bin = "kubectl"
-				}
-				patchCmd := fmt.Sprintf(`
-			OIDC_DISCOVERY_CONFIG_MAP=spire-spiffe-oidc-discovery-provider
-			PATCH_PAYLOAD=$(%[1]s get configmap ${OIDC_DISCOVERY_CONFIG_MAP} -n "%[2]s" -o json | \
-			jq -r '.data["oidc-discovery-provider.conf"] | fromjson |
-			.workload_api.socket_path = "/spiffe-workload-api/socket" |
-			tojson | {data: {"oidc-discovery-provider.conf": .}}')
-			%[1]s patch configmap ${OIDC_DISCOVERY_CONFIG_MAP} -n "%[2]s" --patch "$PATCH_PAYLOAD"
-			`, bin, ztwimNamespace)
-				Eventually(func() error {
-					_, err := shell.ExecuteShell(patchCmd, "")
-					return err
-				}, 60*time.Second, 5*time.Second).Should(Succeed(), "Failed patching OIDC discovery provider configmap")
-
-				By("Restarting OIDC discovery provider deployment")
-				Eventually(func() error {
-					_, err := k.WithNamespace(ztwimNamespace).RolloutRestart("deployment/spire-spiffe-oidc-discovery-provider")
-					return err
-				}, 60*time.Second, 5*time.Second).Should(Succeed(), "Failed to restart OIDC discovery provider")
-
-				By("Waiting for OIDC discovery provider deployment to be available after restart")
-				Eventually(func() error {
-					_, err := k.WithNamespace(ztwimNamespace).RolloutStatus("deployment/spire-spiffe-oidc-discovery-provider")
-					return err
-				}, 300*time.Second, 5*time.Second).Should(Succeed(), "OIDC discovery provider deployment did not become available after restart")
 
 				Success("Spire OIDC Discovery Provider deployed and configured successfully")
 			})
@@ -754,6 +760,14 @@ spec:
 
 				Success("ZTWIM operator stopped and deleted")
 			})
+
+			It("removes subscription from the ZTWIM namespace", func() {
+				Eventually(func() string {
+					output, _ := k.WithNamespace(ztwimNamespace).GetYAML("subscription", ztwimOperatorName)
+					return strings.TrimSpace(output)
+				}, 60*time.Second, 5*time.Second).Should(BeEmpty(), "subscription is not removed")
+				Success("ZTWIM subscription is removed")
+			})
 		})
 
 		When("ZTWIM operands are deleted", func() {
@@ -811,6 +825,19 @@ spec:
 				common.LogDebugInfo(common.Ambient, k)
 				debugInfoLogged = true
 			}
+
+			By("Cleaning up cluster-scoped ZTWIM CRs")
+			clusterScopedCRs := map[string]string{
+				"zerotrustworkloadidentitymanager": "cluster",
+				"spireserver":                      "cluster",
+				"spireagent":                       "cluster",
+				"spiffecsidriver":                  "cluster",
+				"spireoidcdiscoveryprovider":       "cluster",
+			}
+			for kind, name := range clusterScopedCRs {
+				_ = k.DeleteIgnoreNotFound(kind, name)
+			}
+
 			clr.Cleanup(ctx)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

    1. If this is your first time, please read our contributor guidelines: https://github.com/istio-ecosystem/sail-operator/blob/main/CONTRIBUTING.md
    2. Discuss your changes before you start working on them. You can open a new issue in the [Sail Operator GitHub repository](https://github.com/istio-ecosystem/sail-operator/issues) or start a discussion in the [Sail Operator Discussion](https://github.com/istio-ecosystem/sail-operator/discussions). By this way, you can get feedback from the community and ensure that your changes are aligned with the project goals.
    3. If the PR is unfinished, make is as a draft.
-->

#### What type of PR is this?
<!--
In order to minimize the time taken to categorize your PR, add a label accoutring to the PR type defined above.
Please, use the following labels, according to the PR type:
    * Enhancement / New Feature - enhancement
    * Bug Fix - bug
    * Refactor - cleanup/refactor
    * Optimization - enhancement
    * Test - test-e2e
    * Documentation Update - documentation
-->

- [ ] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Test
- [ ] Documentation Update

#### What this PR does / why we need it:

Fixes several e2e test failures across cert-manager, ZTWIM, and control plane update test suites:

**cert-manager:** Fix `CheckPodsReady` to use `istioCSRNamespace` instead of `certManagerNamespace` so IstioCSR pods are checked in the correct namespace.

**ZTWIM:**
- Merge empty `When("ZTWIM Operator Patched")` into `When("ZTWIM Operands Deployed")` so the subscription patch `BeforeAll` actually executes (Ginkgo skips `BeforeAll` when there are no `It` specs in the container)
- Add proxy detection: create `trusted-ca-bundle` ConfigMap and set `TRUSTED_CA_BUNDLE_CONFIGMAP` env var for proxy-enabled clusters
- Wait for operator pods to be ready after subscription patch
- Change SpireServer persistence size from 5Gi to 1Gi to match test cluster NFS PV capacity
- Use `ApplyString` instead of `CreateFromString` for OperatorGroup and Subscription for idempotency
- Remove OIDC configmap `socket_path` patch that pointed to non-existent `/spiffe-workload-api/socket` (actual file is `spire-agent.sock`); the operator now generates the correct path
- Add `It` spec to `When("ZTWIM operator is deleted")` so `BeforeEach` (subscription/CSV deletion) actually runs
- Add cluster-scoped CR cleanup in `AfterAll` using `DeleteIgnoreNotFound` for CRs not tracked by the cleaner

**Control plane updates:** Wrap `PeerAuthentication` creation in `Eventually` with 30s timeout to handle race where the validating webhook is not yet ready to serve.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Add related issue or PR if exists.
-->
Fixes #

#### Additional information:

Tested with multiple runs on IPv6/dual-stack clusters on OCP 4.20 and 4.21.

Files changed:
- `tests/e2e/cert-manager/cert_manager_ambient_test.go`
- `tests/e2e/cert-manager/cert_manager_test.go`
- `tests/e2e/controlplane/control_plane_update_test.go`
- `tests/e2e/ztwim/ztwim_test.go`

  | Commit | 3.0 | 3.1 | 3.2 | 3.3 | 3.4 |
  |--------|-----|-----|-----|-----|-----|
  | `bcc9e087` cert-manager test fix | - | - | yes | yes | yes |
  | `e449e45d` cert-manager ambient fix | - | - | - | - | yes |
  | `175dadde` ZTWIM fix | - | - | - | - | yes |
  | `2b21f567` control plane PeerAuth fix | - | - | - | yes | yes |


