### PR TITLE
Update image digests for OSSM 3.4.1

### DIFF
--- a/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
+++ b/bundle/manifests/servicemeshoperator3.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional, Integration & Delivery, Networking, Security
     containerImage: ${OSSM_OPERATOR_3_4}
-    createdAt: "2026-07-24T14:31:25Z"
+    createdAt: "2026-08-04T17:20:57Z"
     description: The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
@@ -805,11 +805,11 @@ spec:
                   images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:c5374b333fbb37fa6d27c5b83524f2233a546ae4ecc89b1304a9557c8ce6a518
                   images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:234d58ad8033644a72f769ace359a5232c52a2532e851bd374334b3c4cf1d4d8
                   images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cb6adbadc22ca80888f06094c82a402a43526d8a3081e47e6332bcf5355729db
-                  images.v1_27_9.cni: ${ISTIO_CNI_1_27}
-                  images.v1_27_9.istiod: ${ISTIO_PILOT_1_27}
-                  images.v1_27_9.must-gather: ${OSSM_MUST_GATHER_3_2}
-                  images.v1_27_9.proxy: ${ISTIO_PROXY_1_27}
-                  images.v1_27_9.ztunnel: ${ISTIO_ZTUNNEL_1_27}
+                  images.v1_27_9.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6c971034c79cf2152f096d0edd1cc02e709da8cc29a5cfff33f15683ff70f5e0
+                  images.v1_27_9.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c5c6256e72cbe22222727f90d2ac8aa77198daf0543e1870701c1dcda78d583e
+                  images.v1_27_9.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:cd753472f7282a4a1185f6154b85c296a4b90c7bdc3b07b5b96c31c8bc5c5367
+                  images.v1_27_9.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a009354ad551eceb1fb400bc9d5b028ce6aa190e58250a0c8a5b92d91af6b1f8
+                  images.v1_27_9.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:43fbd994ed13313bbb7a0865de0c92ee4bffda91e22796b497b5258705a8e991
                   images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
                   images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
                   images.v1_28_4.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d57d23fc8ec4053a3d819ffb87532d6aec6b5874fdf22e22afdd7f0f0712df52
@@ -830,21 +830,21 @@ spec:
                   images.v1_28_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:50a4a4aacebe31c525bc67735a4fafe4dc4fdaae2abb13d1837872bbaaabfcd2
                   images.v1_28_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:e1c587919c651e10658506ba86637c08e9e2984aae797ab78364dfc2c7e0e0cb
                   images.v1_28_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:dfe3db9c8ca90597d54a21afb090ecfa00353efb110efefcea53fc986ff3c425
-                  images.v1_28_10.cni: ${ISTIO_CNI_1_28}
-                  images.v1_28_10.istiod: ${ISTIO_PILOT_1_28}
-                  images.v1_28_10.must-gather: ${OSSM_MUST_GATHER_3_3}
-                  images.v1_28_10.proxy: ${ISTIO_PROXY_1_28}
-                  images.v1_28_10.ztunnel: ${ISTIO_ZTUNNEL_1_28}
+                  images.v1_28_10.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ecb818cb05241ea2c7847e6e628129cc16d63c87ea2edd153d0fc7b63c5044d2
+                  images.v1_28_10.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:5e1a587977a48afae3440352654d50ab26683e6760fd09407f5c44535d1c5a87
+                  images.v1_28_10.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:c94bf7e54cbd36e2137fefef6245828d9cad80935ce8f4d3bd987acd1d13f2c9
+                  images.v1_28_10.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:c2de9e764bd8703d0b15f2c688ad8d6bb4c56238e2fdc50a9a279fd9607c79de
+                  images.v1_28_10.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:6d1b92b15562d5a242ef11a574599cf0bcec9c6928fb43d8cfe955ae146aef51
                   images.v1_30_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:e27a86751f51b3836c9638b719e14e3f4444ff360e6c3add6be24ee4a1cd436b
                   images.v1_30_1.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:38b1561e4c2d9da341ae4fe809de6a3decabdc861583e52e4a6b85f608682a7f
                   images.v1_30_1.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:879fabc490dadf6dd763630c916b5a48d9382e6f5a55c908c2ea9b6f13f16b0f
                   images.v1_30_1.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:d770608385272197ccf83efa9d1b7b52a01828aa644d875794f025b9d45af381
                   images.v1_30_1.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:194fe2d15251e53544eae4fa5124ec2de2a8bf70646115bb2f9c30b615ff5df5
-                  images.v1_30_3.cni: ${ISTIO_CNI_1_30}
-                  images.v1_30_3.istiod: ${ISTIO_PILOT_1_30}
-                  images.v1_30_3.must-gather: ${OSSM_MUST_GATHER_3_4}
-                  images.v1_30_3.proxy: ${ISTIO_PROXY_1_30}
-                  images.v1_30_3.ztunnel: ${ISTIO_ZTUNNEL_1_30}
+                  images.v1_30_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:80656e6f4d680953d568791338083cb2bef32c443f5f74f227d4e0738be27b4b
+                  images.v1_30_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6a4f5a2ffa5fc9aa687bb812c9b427dc61fc109b846cdf7d70eef28c5fe08faa
+                  images.v1_30_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:be4348faa74481134580e6e13b4c23ac0d2dc758d41a5876c839a170237de000
+                  images.v1_30_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:e8842597aaa261b91be69ffc6501848958de95b714bb7782544d8a923eee619a
+                  images.v1_30_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cfd72e7c8400aa984c0872c63edf8dce83391bc579360ef48d98958a5e45faa7
                   kubectl.kubernetes.io/default-container: sail-operator
                 labels:
                   app.kubernetes.io/created-by: servicemeshoperator3

--- a/ossm/values.yaml
+++ b/ossm/values.yaml
@@ -23,11 +23,11 @@ deployment:
     images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:234d58ad8033644a72f769ace359a5232c52a2532e851bd374334b3c4cf1d4d8
     images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cb6adbadc22ca80888f06094c82a402a43526d8a3081e47e6332bcf5355729db
     # 1.27.9 images after 3.2.7 GA
-    images.v1_27_9.cni: ${ISTIO_CNI_1_27}
-    images.v1_27_9.istiod: ${ISTIO_PILOT_1_27}
-    images.v1_27_9.must-gather: ${OSSM_MUST_GATHER_3_2}
-    images.v1_27_9.proxy: ${ISTIO_PROXY_1_27}
-    images.v1_27_9.ztunnel: ${ISTIO_ZTUNNEL_1_27}
+    images.v1_27_9.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6c971034c79cf2152f096d0edd1cc02e709da8cc29a5cfff33f15683ff70f5e0
+    images.v1_27_9.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c5c6256e72cbe22222727f90d2ac8aa77198daf0543e1870701c1dcda78d583e
+    images.v1_27_9.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:cd753472f7282a4a1185f6154b85c296a4b90c7bdc3b07b5b96c31c8bc5c5367
+    images.v1_27_9.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a009354ad551eceb1fb400bc9d5b028ce6aa190e58250a0c8a5b92d91af6b1f8
+    images.v1_27_9.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:43fbd994ed13313bbb7a0865de0c92ee4bffda91e22796b497b5258705a8e991
     # 1.28.4 images after 3.3.0 GA
     images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
     images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
@@ -53,11 +53,11 @@ deployment:
     images.v1_28_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:e1c587919c651e10658506ba86637c08e9e2984aae797ab78364dfc2c7e0e0cb
     images.v1_28_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:dfe3db9c8ca90597d54a21afb090ecfa00353efb110efefcea53fc986ff3c425
     # 1.28.10 images will be replaced with Konflux built images and will be updated after next patch release
-    images.v1_28_10.cni: ${ISTIO_CNI_1_28}
-    images.v1_28_10.istiod: ${ISTIO_PILOT_1_28}
-    images.v1_28_10.must-gather: ${OSSM_MUST_GATHER_3_3}
-    images.v1_28_10.proxy: ${ISTIO_PROXY_1_28}
-    images.v1_28_10.ztunnel: ${ISTIO_ZTUNNEL_1_28}
+    images.v1_28_10.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ecb818cb05241ea2c7847e6e628129cc16d63c87ea2edd153d0fc7b63c5044d2
+    images.v1_28_10.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:5e1a587977a48afae3440352654d50ab26683e6760fd09407f5c44535d1c5a87
+    images.v1_28_10.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:c94bf7e54cbd36e2137fefef6245828d9cad80935ce8f4d3bd987acd1d13f2c9
+    images.v1_28_10.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:c2de9e764bd8703d0b15f2c688ad8d6bb4c56238e2fdc50a9a279fd9607c79de
+    images.v1_28_10.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:6d1b92b15562d5a242ef11a574599cf0bcec9c6928fb43d8cfe955ae146aef51
     # 1.30.1 images after 3.4.0 GA
     images.v1_30_1.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:e27a86751f51b3836c9638b719e14e3f4444ff360e6c3add6be24ee4a1cd436b
     images.v1_30_1.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:38b1561e4c2d9da341ae4fe809de6a3decabdc861583e52e4a6b85f608682a7f
@@ -65,11 +65,11 @@ deployment:
     images.v1_30_1.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:d770608385272197ccf83efa9d1b7b52a01828aa644d875794f025b9d45af381
     images.v1_30_1.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:194fe2d15251e53544eae4fa5124ec2de2a8bf70646115bb2f9c30b615ff5df5
     # 1.30.1 images will be replaced with Konflux built images and will be updated after next patch release
-    images.v1_30_3.cni: ${ISTIO_CNI_1_30}
-    images.v1_30_3.istiod: ${ISTIO_PILOT_1_30}
-    images.v1_30_3.must-gather: ${OSSM_MUST_GATHER_3_4}
-    images.v1_30_3.proxy: ${ISTIO_PROXY_1_30}
-    images.v1_30_3.ztunnel: ${ISTIO_ZTUNNEL_1_30}
+    images.v1_30_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:80656e6f4d680953d568791338083cb2bef32c443f5f74f227d4e0738be27b4b
+    images.v1_30_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6a4f5a2ffa5fc9aa687bb812c9b427dc61fc109b846cdf7d70eef28c5fe08faa
+    images.v1_30_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:be4348faa74481134580e6e13b4c23ac0d2dc758d41a5876c839a170237de000
+    images.v1_30_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:e8842597aaa261b91be69ffc6501848958de95b714bb7782544d8a923eee619a
+    images.v1_30_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:cfd72e7c8400aa984c0872c63edf8dce83391bc579360ef48d98958a5e45faa7
 service:
   port: 8443
 serviceAccountName: servicemesh-operator3


### PR DESCRIPTION
Update container image digests for OSSM 3.4.1 after GA release.