### PR TITLE
OSSM-15257: add RBAC aggregation ClusterRoles for istio.io CRDs in li…

### DIFF
--- a/pkg/install/aggregation_rbac.go
+++ b/pkg/install/aggregation_rbac.go
@@ -1,0 +1,160 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type aggregationRole struct {
+	suffix string
+	label  string
+	verbs  []string
+}
+
+var aggregationRoles = []aggregationRole{
+	{
+		suffix: "admin",
+		label:  "rbac.authorization.k8s.io/aggregate-to-admin",
+		verbs:  []string{"*"},
+	},
+	{
+		suffix: "edit",
+		label:  "rbac.authorization.k8s.io/aggregate-to-edit",
+		verbs:  []string{"create", "delete", "patch", "update"},
+	},
+	{
+		suffix: "view",
+		label:  "rbac.authorization.k8s.io/aggregate-to-view",
+		verbs:  []string{"get", "list", "watch"},
+	},
+}
+
+func aggregationClusterRoleName(revision, suffix string) string {
+	return fmt.Sprintf("istio-crd-%s-%s", suffix, revision)
+}
+
+func rulesFromCRDNames(crdNames []string, verbs []string) []rbacv1.PolicyRule {
+	groupResources := make(map[string][]string)
+	var groupOrder []string
+	for _, name := range crdNames {
+		parts := strings.SplitN(name, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		plural := parts[0]
+		group := parts[1]
+		if _, exists := groupResources[group]; !exists {
+			groupOrder = append(groupOrder, group)
+		}
+		groupResources[group] = append(groupResources[group], plural)
+	}
+
+	rules := make([]rbacv1.PolicyRule, 0, len(groupOrder))
+	for _, group := range groupOrder {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{group},
+			Resources: groupResources[group],
+			Verbs:     verbs,
+		})
+	}
+	return rules
+}
+
+func reconcileAggregationClusterRoles(ctx context.Context, cl client.Client, cm *crdManager, revision string) error {
+	log := logf.FromContext(ctx)
+
+	if cm == nil || cm.crdFS == nil {
+		return nil
+	}
+
+	crds, err := cm.loadCRDsMatching(Options{IncludeAllCRDs: true}, aggregatableCRD)
+	if err != nil {
+		return fmt.Errorf("failed to load Istio CRDs: %w", err)
+	}
+
+	crdNames := make([]string, 0, len(crds))
+	for _, crd := range crds {
+		crdNames = append(crdNames, crd.Name)
+	}
+	if len(crdNames) == 0 {
+		return nil
+	}
+
+	for _, ar := range aggregationRoles {
+		name := aggregationClusterRoleName(revision, ar.suffix)
+		labels := map[string]string{
+			managedByLabelKey: managedByValue,
+			ar.label:          "true",
+		}
+		rules := rulesFromCRDNames(crdNames, ar.verbs)
+
+		desired := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+			},
+			Rules: rules,
+		}
+
+		existing := &rbacv1.ClusterRole{}
+		err := cl.Get(ctx, client.ObjectKeyFromObject(desired), existing)
+		if apierrors.IsNotFound(err) {
+			log.V(2).Info("Creating aggregation ClusterRole", "name", name)
+			if err := cl.Create(ctx, desired); err != nil {
+				return fmt.Errorf("failed to create aggregation ClusterRole %s: %w", name, err)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get aggregation ClusterRole %s: %w", name, err)
+		}
+
+		existing.Labels = labels
+		existing.Rules = rules
+		log.V(2).Info("Updating aggregation ClusterRole", "name", name)
+		if err := cl.Update(ctx, existing); err != nil {
+			return fmt.Errorf("failed to update aggregation ClusterRole %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func deleteAggregationClusterRoles(ctx context.Context, cl client.Client, revision string) error {
+	log := logf.FromContext(ctx)
+
+	for _, ar := range aggregationRoles {
+		name := aggregationClusterRoleName(revision, ar.suffix)
+		cr := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+		if err := cl.Delete(ctx, cr); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to delete aggregation ClusterRole %s: %w", name, err)
+		}
+		log.V(2).Info("Deleted aggregation ClusterRole", "name", name)
+	}
+	return nil
+}

--- a/pkg/install/aggregation_rbac_test.go
+++ b/pkg/install/aggregation_rbac_test.go
@@ -1,0 +1,201 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/istio-ecosystem/sail-operator/chart"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newFakeRBACClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func newTestCRDManager() *crdManager {
+	return &crdManager{crdFS: chart.CRDsFS}
+}
+
+func TestReconcileAggregationClusterRoles_Creates(t *testing.T) {
+	cl := newFakeRBACClient()
+	revision := "default"
+
+	err := reconcileAggregationClusterRoles(context.Background(), cl, newTestCRDManager(), revision)
+	require.NoError(t, err)
+
+	for _, ar := range aggregationRoles {
+		name := aggregationClusterRoleName(revision, ar.suffix)
+		cr := &rbacv1.ClusterRole{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: name}, cr)
+		require.NoError(t, err, "ClusterRole %s should exist", name)
+
+		assert.Equal(t, managedByValue, cr.Labels[managedByLabelKey])
+		assert.Equal(t, "true", cr.Labels[ar.label])
+		assert.NotEmpty(t, cr.Rules, "ClusterRole %s should have rules", name)
+	}
+}
+
+func TestReconcileAggregationClusterRoles_Updates(t *testing.T) {
+	revision := "test-revision"
+	existing := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   aggregationClusterRoleName(revision, "admin"),
+			Labels: map[string]string{"old-label": "old-value"},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"old"}, Resources: []string{"old"}, Verbs: []string{"get"}},
+		},
+	}
+	cl := newFakeRBACClient(existing)
+
+	err := reconcileAggregationClusterRoles(context.Background(), cl, newTestCRDManager(), revision)
+	require.NoError(t, err)
+
+	cr := &rbacv1.ClusterRole{}
+	err = cl.Get(context.Background(), client.ObjectKey{Name: aggregationClusterRoleName(revision, "admin")}, cr)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", cr.Labels["rbac.authorization.k8s.io/aggregate-to-admin"])
+	assert.Equal(t, managedByValue, cr.Labels[managedByLabelKey])
+	assert.NotContains(t, cr.Labels, "old-label")
+	assert.NotEmpty(t, cr.Rules)
+}
+
+func TestDeleteAggregationClusterRoles(t *testing.T) {
+	revision := "test-revision"
+	cl := newFakeRBACClient()
+
+	err := reconcileAggregationClusterRoles(context.Background(), cl, newTestCRDManager(), revision)
+	require.NoError(t, err)
+
+	err = deleteAggregationClusterRoles(context.Background(), cl, revision)
+	require.NoError(t, err)
+
+	for _, ar := range aggregationRoles {
+		name := aggregationClusterRoleName(revision, ar.suffix)
+		cr := &rbacv1.ClusterRole{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: name}, cr)
+		assert.Error(t, err, "ClusterRole %s should be deleted", name)
+	}
+}
+
+func TestDeleteAggregationClusterRoles_NotFound(t *testing.T) {
+	cl := newFakeRBACClient()
+	err := deleteAggregationClusterRoles(context.Background(), cl, "nonexistent")
+	require.NoError(t, err)
+}
+
+func TestAggregationClusterRoleName(t *testing.T) {
+	assert.Equal(t, "istio-crd-admin-my-rev", aggregationClusterRoleName("my-rev", "admin"))
+	assert.Equal(t, "istio-crd-edit-my-rev", aggregationClusterRoleName("my-rev", "edit"))
+	assert.Equal(t, "istio-crd-view-my-rev", aggregationClusterRoleName("my-rev", "view"))
+}
+
+func TestRulesFromCRDNames(t *testing.T) {
+	crdNames := []string{
+		"telemetries.telemetry.istio.io",
+		"virtualservices.networking.istio.io",
+		"gateways.networking.istio.io",
+		"authorizationpolicies.security.istio.io",
+	}
+	verbs := []string{"get", "list", "watch"}
+
+	rules := rulesFromCRDNames(crdNames, verbs)
+
+	assert.Len(t, rules, 3, "should have 3 rules (one per API group)")
+
+	groupMap := make(map[string]rbacv1.PolicyRule)
+	for _, r := range rules {
+		groupMap[r.APIGroups[0]] = r
+	}
+
+	assert.Contains(t, groupMap["telemetry.istio.io"].Resources, "telemetries")
+	assert.Contains(t, groupMap["networking.istio.io"].Resources, "virtualservices")
+	assert.Contains(t, groupMap["networking.istio.io"].Resources, "gateways")
+	assert.Contains(t, groupMap["security.istio.io"].Resources, "authorizationpolicies")
+
+	for _, r := range rules {
+		assert.Equal(t, verbs, r.Verbs)
+	}
+}
+
+func TestRulesFromCRDNames_MatchesCRDFiles(t *testing.T) {
+	cm := newTestCRDManager()
+	crds, err := cm.loadCRDsMatching(Options{IncludeAllCRDs: true}, aggregatableCRD)
+	require.NoError(t, err)
+	require.NotEmpty(t, crds)
+
+	var crdNames []string
+	for _, crd := range crds {
+		crdNames = append(crdNames, crd.Name)
+	}
+
+	rules := rulesFromCRDNames(crdNames, []string{"get"})
+
+	expectedGroups := map[string]bool{
+		"networking.istio.io": false,
+		"security.istio.io":   false,
+		"telemetry.istio.io":  false,
+		"extensions.istio.io": false,
+		"sailoperator.io":     false,
+	}
+	for _, rule := range rules {
+		for _, group := range rule.APIGroups {
+			if _, ok := expectedGroups[group]; ok {
+				expectedGroups[group] = true
+			}
+		}
+	}
+	for group, found := range expectedGroups {
+		assert.True(t, found, "rules should cover API group %s", group)
+	}
+}
+
+func TestAggregationRoles_ViewHasReadOnlyVerbs(t *testing.T) {
+	for _, ar := range aggregationRoles {
+		if ar.suffix == "view" {
+			assert.Equal(t, []string{"get", "list", "watch"}, ar.verbs)
+		}
+	}
+}
+
+func TestAggregationRoles_AdminHasAllVerbs(t *testing.T) {
+	for _, ar := range aggregationRoles {
+		if ar.suffix == "admin" {
+			assert.Equal(t, []string{"*"}, ar.verbs)
+		}
+	}
+}
+
+func TestAggregationRoles_EditHasWriteOnlyVerbs(t *testing.T) {
+	for _, ar := range aggregationRoles {
+		if ar.suffix == "edit" {
+			assert.Equal(t, []string{"create", "delete", "patch", "update"}, ar.verbs)
+			assert.NotContains(t, ar.verbs, "get")
+			assert.NotContains(t, ar.verbs, "list")
+			assert.NotContains(t, ar.verbs, "watch")
+		}
+	}
+}

--- a/pkg/install/crds.go
+++ b/pkg/install/crds.go
@@ -137,7 +137,13 @@ func (m *crdManager) isCRDReady(crd *apiextensionsv1.CustomResourceDefinition) b
 	return false
 }
 
+type crdGroupFilter func(*apiextensionsv1.CustomResourceDefinition) bool
+
 func (m *crdManager) loadCRDs(opts Options) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	return m.loadCRDsMatching(opts, istioCRD)
+}
+
+func (m *crdManager) loadCRDsMatching(opts Options, groupAccept crdGroupFilter) ([]*apiextensionsv1.CustomResourceDefinition, error) {
 	targetKinds := targetCRDKinds(opts.IncludeAllCRDs, opts.Values)
 
 	var crds []*apiextensionsv1.CustomResourceDefinition
@@ -163,7 +169,7 @@ func (m *crdManager) loadCRDs(opts Options) ([]*apiextensionsv1.CustomResourceDe
 			if crd.Kind != "CustomResourceDefinition" {
 				continue
 			}
-			if !istioCRD(&crd) {
+			if !groupAccept(&crd) {
 				continue
 			}
 			if opts.IncludeAllCRDs || matchesCRDFilter(&crd, targetKinds) {
@@ -198,6 +204,14 @@ func AggregateState(infos []CRDInfo) (CRDManagementState, string) {
 
 func istioCRD(crd *apiextensionsv1.CustomResourceDefinition) bool {
 	return strings.HasSuffix(crd.Spec.Group, ".istio.io")
+}
+
+func sailCRD(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	return strings.HasSuffix(crd.Spec.Group, "sailoperator.io")
+}
+
+func aggregatableCRD(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	return istioCRD(crd) || sailCRD(crd)
 }
 
 func matchesCRDFilter(crd *apiextensionsv1.CustomResourceDefinition, targetKinds map[string]bool) bool {

--- a/pkg/install/rbac.go
+++ b/pkg/install/rbac.go
@@ -73,6 +73,7 @@ func LibraryRBACRules() []rbacv1.PolicyRule {
 	addEntry("", "pods", readOnlyVerbs)
 	addEntry("", "secrets", helmManagedVerbs)
 	addEntry("apiextensions.k8s.io", "customresourcedefinitions", crdVerbs)
+	addEntry("rbac.authorization.k8s.io", "clusterroles", []string{"escalate"})
 
 	var rules []rbacv1.PolicyRule
 	for key, resources := range grouped {

--- a/pkg/install/rbac_test.go
+++ b/pkg/install/rbac_test.go
@@ -66,6 +66,19 @@ func TestLibraryRBACRules_EndpointSliceIsReadOnly(t *testing.T) {
 	t.Fatal("endpointslices rule not found")
 }
 
+func TestLibraryRBACRules_ClusterRolesEscalate(t *testing.T) {
+	g := NewWithT(t)
+	found := false
+	for _, rule := range LibraryRBACRules() {
+		if slices.Contains(rule.APIGroups, "rbac.authorization.k8s.io") &&
+			slices.Contains(rule.Resources, "clusterroles") &&
+			slices.Contains(rule.Verbs, "escalate") {
+			found = true
+		}
+	}
+	g.Expect(found).To(BeTrue(), "escalate on clusterroles is required so the operator can create the aggregation ClusterRoles")
+}
+
 func TestLibraryRBACRules_CRDsNoDelete(t *testing.T) {
 	g := NewWithT(t)
 	for _, rule := range LibraryRBACRules() {

--- a/pkg/install/reconciler.go
+++ b/pkg/install/reconciler.go
@@ -255,10 +255,20 @@ func (inst *installer) reconcile(ctx context.Context, opts Options) Status {
 		return status
 	}
 
+	if opts.ManageCRDs {
+		if err := reconcileAggregationClusterRoles(ctx, inst.crdManager.cl, inst.crdManager, revisionName); err != nil {
+			status.Error = fmt.Errorf("failed to reconcile RBAC aggregation ClusterRoles: %w", err)
+			return status
+		}
+	}
+
 	status.Installed = true
 	return status
 }
 
 func (inst *installer) uninstall(ctx context.Context, namespace, revisionName string) error {
-	return inst.istiodReconciler.Uninstall(ctx, namespace, revisionName)
+	if err := inst.istiodReconciler.Uninstall(ctx, namespace, revisionName); err != nil {
+		return err
+	}
+	return deleteAggregationClusterRoles(ctx, inst.crdManager.cl, revisionName)
 }


### PR DESCRIPTION
  #### What type of PR is this?

  - [ ] Enhancement / New Feature
  - [x] Bug Fix
  - [ ] Refactor
  - [ ] Optimization
  - [ ] Test
  - [ ] Documentation Update

  #### What this PR does / why we need it:

  When istiod is installed via the `pkg/install` library (used by ClusterIngressOperator), RBAC aggregation ClusterRoles for `istio.io` CRDs are not created. This prevents namespace admins from managing Istio
  resources (Telemetry, VirtualService, AuthorizationPolicy, etc.) — only cluster-admins can.

  OLM automatically creates these aggregation ClusterRoles when the operator is installed from the marketplace, but the library install path has no OLM, so they are missing.

  This PR adds `reconcileAggregationClusterRoles` and `deleteAggregationClusterRoles` to the library installer (`pkg/install`). RBAC rules are dynamically derived from CRD files, and verbs match OLM
  convention exactly:
  - **admin**: `*`
  - **edit**: `create`, `delete`, `patch`, `update`
  - **view**: `get`, `list`, `watch`

  ClusterRoles are labeled with `managed-by: sail-library` and the appropriate `rbac.authorization.k8s.io/aggregate-to-{admin,edit,view}` label so Kubernetes automatically aggregates them into the built-in
  `admin`, `edit`, and `view` ClusterRoles.

  #### Which issue(s) this PR fixes:
- [OSSM-15257](https://redhat.atlassian.net/browse/OSSM-15257)

#### Additional information:

Some custom test againts live Openshift cluster (test is not part of PR, used for verification):

```
=== RUN   TestLiveAggregationClusterRoles
    === Step 1: reconcileAggregationClusterRoles (as installer SA holding LibraryRBACRules incl. escalate) ===
    Created aggregation ClusterRoles successfully
    === Step 2: Verify ClusterRoles ===
    ClusterRole istio-crd-admin-live-test: labels=map[managed-by:sail-library rbac.authorization.k8s.io/aggregate-to-admin:true], rules=5 groups
      apiGroups=[extensions.istio.io] resources=[trafficextensions wasmplugins] verbs=[*]
      apiGroups=[networking.istio.io] resources=[destinationrules envoyfilters gateways proxyconfigs serviceentries sidecars virtualservices workloadentries workloadgroups] verbs=[*]
      apiGroups=[sailoperator.io] resources=[istiocnis istiorevisions istiorevisiontags istios ztunnels] verbs=[*]
      apiGroups=[security.istio.io] resources=[authorizationpolicies peerauthentications requestauthentications] verbs=[*]
      apiGroups=[telemetry.istio.io] resources=[telemetries] verbs=[*]
    ClusterRole istio-crd-edit-live-test: labels=map[managed-by:sail-library rbac.authorization.k8s.io/aggregate-to-edit:true], rules=5 groups
      apiGroups=[extensions.istio.io] resources=[trafficextensions wasmplugins] verbs=[create delete patch update]
      apiGroups=[networking.istio.io] resources=[destinationrules envoyfilters gateways proxyconfigs serviceentries sidecars virtualservices workloadentries workloadgroups] verbs=[create delete patch update]
      apiGroups=[sailoperator.io] resources=[istiocnis istiorevisions istiorevisiontags istios ztunnels] verbs=[create delete patch update]
      apiGroups=[security.istio.io] resources=[authorizationpolicies peerauthentications requestauthentications] verbs=[create delete patch update]
      apiGroups=[telemetry.istio.io] resources=[telemetries] verbs=[create delete patch update]
    ClusterRole istio-crd-view-live-test: labels=map[managed-by:sail-library rbac.authorization.k8s.io/aggregate-to-view:true], rules=5 groups
      apiGroups=[extensions.istio.io] resources=[trafficextensions wasmplugins] verbs=[get list watch]
      apiGroups=[networking.istio.io] resources=[destinationrules envoyfilters gateways proxyconfigs serviceentries sidecars virtualservices workloadentries workloadgroups] verbs=[get list watch]
      apiGroups=[sailoperator.io] resources=[istiocnis istiorevisions istiorevisiontags istios ztunnels] verbs=[get list watch]
      apiGroups=[security.istio.io] resources=[authorizationpolicies peerauthentications requestauthentications] verbs=[get list watch]
      apiGroups=[telemetry.istio.io] resources=[telemetries] verbs=[get list watch]
    === Step 3: Idempotency check ===
    Second reconcile succeeded (idempotent)
    === Step 4: deleteAggregationClusterRoles ===
    Deleted aggregation ClusterRoles successfully
    === Step 5: Verify cleanup ===
    ClusterRole istio-crd-admin-live-test: gone (confirmed)
    ClusterRole istio-crd-edit-live-test: gone (confirmed)
    ClusterRole istio-crd-view-live-test: gone (confirmed)
--- PASS: TestLiveAggregationClusterRoles (13.93s)
PASS
  ```

#### Required:
- Cherry pick to release-3.4
- Cherry pick to release-3.3 (but with other missed commits from main, need to check it manually)