### PR TITLE
test: manual sync upstream flaky-test fixes with CheckPodConnectivity fix

### DIFF
--- a/tests/e2e/ambient/ambient_test.go
+++ b/tests/e2e/ambient/ambient_test.go
@@ -247,11 +247,17 @@ spec:
 					})
 
 					It("has the ztunnel proxy sockets configured in the pod network namespace", func(ctx SpecContext) {
-						checkZtunnelPort(sleepPod.Items[0].Name, common.SleepNamespace)
+						// Ztunnel configures the HBONE port (15008) in the pod network namespace
+						// asynchronously after the pod becomes Ready. Retry to avoid flakes on
+						// slow clusters (e.g. OCP ARM) where the socket may not be visible yet.
+						Eventually(func(g Gomega) {
+							checkZtunnelPort(g, sleepPod.Items[0].Name, common.SleepNamespace)
+						}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(Succeed(),
+							"ztunnel should configure port 15008 in the pod network namespace")
 					})
 
 					It("can access the httpbin service from the sleep pod", func(ctx SpecContext) {
-						common.CheckPodConnectivity(sleepPod.Items[0].Name, common.SleepNamespace, common.HttpbinNamespace, k)
+						checkPodConnectivity(sleepPod.Items[0].Name, common.SleepNamespace, common.HttpbinNamespace)
 					})
 				})
 
@@ -335,9 +341,16 @@ func getEnvVars(container corev1.Container) []corev1.EnvVar {
 	return container.Env
 }
 
-func checkZtunnelPort(podName, srcNamespace string) {
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, "netstat -tlpn")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
+func checkPodConnectivity(podName, srcNamespace, destNamespace string) {
+	command := fmt.Sprintf(`curl -o /dev/null -s -w "%%{http_code}\n" httpbin.%s.svc.cluster.local:8000/get`, destNamespace)
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, command)
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
+	Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", podName))
+}
+
+func checkZtunnelPort(g Gomega, podName, srcNamespace string) {
+	response, err := k.WithNamespace(srcNamespace).Exec(podName, "sleep", "netstat -tlpn")
+	g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error validating the proxy sockets in the %q pod", podName))
 	// Verify that the HBONE mTLS tunnel port (15008) is listed in the output.
-	Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
+	g.Expect(response).To(ContainSubstring("15008"), fmt.Sprintf("Unexpected response from %s pod", podName))
 }

--- a/tests/e2e/cert-manager/cert_manager_test.go
+++ b/tests/e2e/cert-manager/cert_manager_test.go
@@ -337,7 +337,10 @@ spec:
 
 				// Any logging or diagnostics should also be inside this block
 				time.Sleep(60 * time.Second)
-				common.CheckPodConnectivity(sleepPod.Items[0].Name, common.SleepNamespace, common.HttpbinNamespace, k)
+				command := fmt.Sprintf(`curl -o /dev/null -s -w "%%{http_code}\n" httpbin.%s.svc.cluster.local:8000/get`, common.HttpbinNamespace)
+				response, err := k.WithNamespace(common.SleepNamespace).Exec(sleepPod.Items[0].Name, common.SleepNamespace, command)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", sleepPod.Items[0].Name))
+				Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", sleepPod.Items[0].Name))
 			})
 		})
 

--- a/tests/e2e/controlplane/control_plane_test.go
+++ b/tests/e2e/controlplane/control_plane_test.go
@@ -201,11 +201,13 @@ metadata:
 					})
 
 					It("has sidecars with the correct istio version", func(ctx SpecContext) {
-						for _, pod := range samplePods.Items {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-							Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
-						}
+						Eventually(func(g Gomega) {
+							for _, pod := range samplePods.Items {
+								sidecarVersion, err := common.GetProxyVersion(pod.Name, sampleNamespace)
+								g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+								g.Expect(sidecarVersion).To(Equal(version.Version), "Sidecar Istio version does not match the expected version")
+							}
+						}).Should(Succeed(), "Error verifying sidecar version")
 						Success("Istio sidecar version matches the expected Istio version")
 					})
 				})

--- a/tests/e2e/controlplane/control_plane_update_test.go
+++ b/tests/e2e/controlplane/control_plane_update_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/istioversion"
 	"github.com/istio-ecosystem/sail-operator/pkg/kube"
@@ -130,9 +129,12 @@ spec:
 					Success("sample pods are ready")
 
 					for _, pod := range samplePods.Items {
-						sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-						Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-						Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						podName := pod.Name
+						Eventually(func(g Gomega) {
+							sidecarVersion, err := common.GetProxyVersionFromPod(podName, sampleNamespace)
+							g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+							g.Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						}).Should(Succeed(), "Error verifying sidecar version for pod "+podName)
 					}
 					Success("Istio sidecar version matches the expected base Istio version")
 				})
@@ -202,11 +204,15 @@ spec:
 					Expect(samplePods.Items).ToNot(BeEmpty(), "No pods found in sample namespace")
 
 					for _, pod := range samplePods.Items {
-						Eventually(func() *semver.Version {
-							sidecarVersion, err := getProxyVersion(pod.Name, sampleNamespace)
-							Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
-							return sidecarVersion
-						}).Should(Equal(istioversion.Map[istioversion.Base].Version), "Sidecar Istio version does not match the expected version")
+						podName := pod.Name
+						Eventually(func(g Gomega) {
+							// Use GetProxyVersionFromPod to avoid XDS authentication issues
+							// that can occur during control plane upgrades when two istiod pods
+							// are running simultaneously on OCP.
+							sidecarVersion, err := common.GetProxyVersionFromPod(podName, sampleNamespace)
+							g.Expect(err).NotTo(HaveOccurred(), "Error getting sidecar version")
+							g.Expect(sidecarVersion).To(Equal(istioversion.Map[istioversion.Base].Version))
+						}).Should(Succeed(), "Sidecar Istio version does not match the expected version")
 					}
 					Success("Istio sidecar version matches the expected Istio version")
 				})

--- a/tests/e2e/util/common/e2e_utils.go
+++ b/tests/e2e/util/common/e2e_utils.go
@@ -34,6 +34,7 @@ import (
 	"github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/istio/pkg/ptr"
@@ -451,17 +452,138 @@ func withClusterName(m string, k kubectl.Kubectl) string {
 	return m + " on " + k.ClusterName
 }
 
-func CheckPodConnectivity(podName, srcNamespace, destNamespace string, k kubectl.Kubectl) {
-	command := fmt.Sprintf(`curl -o /dev/null -s -w "%%{http_code}\n" httpbin.%s.svc.cluster.local:8000/get`, destNamespace)
-	response, err := k.WithNamespace(srcNamespace).Exec(podName, srcNamespace, command)
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error connecting to the %q pod", podName))
-	Expect(response).To(ContainSubstring("200"), fmt.Sprintf("Unexpected response from %s pod", podName))
-}
-
 func HaveContainersThat(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return HaveField("Spec.Template.Spec.Containers", matcher)
 }
 
 func ImageFromRegistry(regexp string) types.GomegaMatcher {
 	return HaveField("Image", MatchRegexp(regexp))
+}
+
+func EnsureNamespace(ctx context.Context, ctrlclient client.Client, namespace string) *corev1.Namespace {
+	GinkgoHelper()
+	ns := &corev1.Namespace{}
+	if err := ctrlclient.Get(ctx, client.ObjectKey{Name: namespace}, ns); apierrors.IsNotFound(err) {
+		ns.Name = namespace
+		if err := ctrlclient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			Fail(fmt.Sprintf("Failed to create namespace: %s", err))
+		}
+	} else if err != nil {
+		Fail(fmt.Sprintf("Failed to get namespace: %s", err))
+	}
+	return ns
+}
+
+func EnsureNamespaceWithCleanup(k kubectl.Kubectl, namespace string) {
+	GinkgoHelper()
+	Expect(k.CreateNamespace(namespace)).To(Succeed())
+	DeferCleanup(func() {
+		if err := k.Delete("namespace", namespace); err != nil {
+			Log(fmt.Sprintf("Failed to delete namespace: %s", err))
+		}
+	})
+}
+
+// GetProxyVersion extracts the Istio proxy version from a pod using istioctl proxy-status
+func GetProxyVersion(podName, namespace string) (*semver.Version, error) {
+	proxyStatus, err := istioctl.GetProxyStatus("--namespace " + namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting proxy version: %w", err)
+	}
+
+	lines := strings.Split(proxyStatus, "\n")
+	colSplit := regexp.MustCompile(`\s{2,}`)
+
+	versionIdx := -1
+	headers := colSplit.Split(strings.TrimSpace(lines[0]), -1)
+	for i, header := range headers {
+		if header == "VERSION" {
+			versionIdx = i
+			break
+		}
+	}
+	if versionIdx == -1 {
+		return nil, fmt.Errorf("VERSION header not found")
+	}
+
+	var versionStr string
+	for _, line := range lines[1:] {
+		if strings.Contains(line, podName+"."+namespace) {
+			values := colSplit.Split(strings.TrimSpace(line), -1)
+			if versionIdx < len(values) {
+				versionStr = values[versionIdx]
+				break
+			}
+		}
+	}
+
+	if versionStr == "" {
+		return nil, fmt.Errorf("pod %s not found in proxy status output for namespace %s", podName, namespace)
+	}
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return version, fmt.Errorf("error parsing proxy version %q: %w", versionStr, err)
+	}
+	return version, err
+}
+
+// GetProxyVersionFromPod extracts the Istio proxy version directly from the pod's
+// istio-proxy container by executing pilot-agent version. This approach does not
+// require XDS connectivity to istiod, making it more reliable during control plane
+// upgrades when istiod may be temporarily inaccessible.
+func GetProxyVersionFromPod(podName, namespace string) (*semver.Version, error) {
+	k := kubectl.New().WithNamespace(namespace)
+	output, err := k.Exec(podName, "istio-proxy", "pilot-agent version")
+	if err != nil {
+		return nil, fmt.Errorf("error getting proxy version from pod %s: %w", podName, err)
+	}
+
+	matches := istiodVersionRegex.FindStringSubmatch(output)
+	if len(matches) > 1 && matches[1] != "" {
+		return semver.NewVersion(matches[1])
+	}
+	return nil, fmt.Errorf("error getting proxy version from pod %s: version not found in output: %s", podName, output)
+}
+
+// GetIstioProxyContainer finds and returns the istio-proxy container from a pod
+// It checks both regular containers and init containers (for persistent init containers in K8s 1.28+)
+// Returns the container if found, nil otherwise
+func GetIstioProxyContainer(pod corev1.Pod) *corev1.Container {
+	// Check regular containers
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "istio-proxy" {
+			return &pod.Spec.Containers[i]
+		}
+	}
+
+	// Check init containers
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == "istio-proxy" {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+
+	return nil
+}
+
+// HasSidecarInjected checks if a pod has the istio-proxy sidecar injected
+func HasSidecarInjected(pod corev1.Pod) bool {
+	return GetIstioProxyContainer(pod) != nil
+}
+
+// HasHBONEEnabled checks if the istio-proxy sidecar has HBONE capability enabled
+// by verifying the ISTIO_META_ENABLE_HBONE environment variable is set to "true"
+func HasHBONEEnabled(pod corev1.Pod) bool {
+	container := GetIstioProxyContainer(pod)
+	if container == nil {
+		return false
+	}
+
+	for _, env := range container.Env {
+		if env.Name == "ISTIO_META_ENABLE_HBONE" && env.Value == "true" {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Summary

Manual sync of upstream changes from PR #1088 (automator) with a fix for the typecheck lint failure it introduced.

- Cherry-picks the two upstream commits from the automator PR:
  - `test: fix flaky step on TestAmbient (#2222) (#2241)`
  - `[release-1.27] test: improve steps to avoid flaky failures on CI (#2216) (#2239)`
- Adds a fix commit: the second commit removes `common.CheckPodConnectivity` from `e2e_utils.go` but two callers remained, causing `undefined: common.CheckPodConnectivity (typecheck)` in lint CI. The fix inlines the equivalent curl exec at both call sites.

## Fixes

Closes the lint failure seen in: https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift-service-mesh_sail-operator/1088/pull-ci-openshift-service-mesh-sail-operator-release-3.2-ocp-4.22-lint/2088208509983264768/build-log.txt
